### PR TITLE
fix(labeler): quote YAML label names to fix syntax error

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,22 +3,22 @@
 # - area: for ownership/surface
 # - type: for nature of change
 
-area: agents:
+"area: agents":
   - changed-files:
       - any-glob-to-any-file:
           - "agents/**"
 
-area: shared:
+"area: shared":
   - changed-files:
       - any-glob-to-any-file:
           - "shared/**"
 
-area: tests:
+"area: tests":
   - changed-files:
       - any-glob-to-any-file:
           - "tests/**"
 
-area: docs:
+"area: docs":
   - changed-files:
       - any-glob-to-any-file:
           - "README.md"
@@ -29,44 +29,44 @@ area: docs:
           - "CODE_OF_CONDUCT.md"
           - "docs/**"
 
-area: infra:
+"area: infra":
   - changed-files:
       - any-glob-to-any-file:
           - "docker/**"
           - "docker-compose.yml"
           - "config/**"
 
-area: ci:
+"area: ci":
   - changed-files:
       - any-glob-to-any-file:
           - ".github/workflows/**"
           - ".pre-commit-config.yaml"
 
-type: feature:
+"type: feature":
   - head-branch:
-      - "^feat(/|-)"
-      - "^feature(/|-)"
+      - "^feat[/-]"
+      - "^feature[/-]"
 
-type: bugfix:
+"type: bugfix":
   - head-branch:
-      - "^fix(/|-)"
-      - "^bugfix(/|-)"
-      - "^hotfix(/|-)"
+      - "^fix[/-]"
+      - "^bugfix[/-]"
+      - "^hotfix[/-]"
 
-type: refactor:
+"type: refactor":
   - head-branch:
-      - "^refactor(/|-)"
-      - "^chore/refactor(/|-)"
+      - "^refactor[/-]"
+      - "^chore/refactor[/-]"
 
-type: chore:
+"type: chore":
   - head-branch:
-      - "^chore(/|-)"
-      - "^build(/|-)"
-      - "^ci(/|-)"
+      - "^chore[/-]"
+      - "^build[/-]"
+      - "^ci[/-]"
 
-type: docs:
+"type: docs":
   - head-branch:
-      - "^docs(/|-)"
+      - "^docs[/-]"
   - changed-files:
       - any-glob-to-any-file:
           - "README.md"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,76 +3,76 @@
 # - area: for ownership/surface
 # - type: for nature of change
 
-"area: agents":
+'area: agents':
   - changed-files:
       - any-glob-to-any-file:
-          - "agents/**"
+          - 'agents/**'
 
-"area: shared":
+'area: shared':
   - changed-files:
       - any-glob-to-any-file:
-          - "shared/**"
+          - 'shared/**'
 
-"area: tests":
+'area: tests':
   - changed-files:
       - any-glob-to-any-file:
-          - "tests/**"
+          - 'tests/**'
 
-"area: docs":
+'area: docs':
   - changed-files:
       - any-glob-to-any-file:
-          - "README.md"
-          - "CONTRIBUTING.md"
-          - "AGENTS.md"
-          - "CHANGELOG.md"
-          - "SECURITY.md"
-          - "CODE_OF_CONDUCT.md"
-          - "docs/**"
+          - 'README.md'
+          - 'CONTRIBUTING.md'
+          - 'AGENTS.md'
+          - 'CHANGELOG.md'
+          - 'SECURITY.md'
+          - 'CODE_OF_CONDUCT.md'
+          - 'docs/**'
 
-"area: infra":
+'area: infra':
   - changed-files:
       - any-glob-to-any-file:
-          - "docker/**"
-          - "docker-compose.yml"
-          - "config/**"
+          - 'docker/**'
+          - 'docker-compose.yml'
+          - 'config/**'
 
-"area: ci":
+'area: ci':
   - changed-files:
       - any-glob-to-any-file:
-          - ".github/workflows/**"
-          - ".pre-commit-config.yaml"
+          - '.github/workflows/**'
+          - '.pre-commit-config.yaml'
 
-"type: feature":
+'type: feature':
   - head-branch:
-      - "^feat[/-]"
-      - "^feature[/-]"
+      - '^feat[/-]'
+      - '^feature[/-]'
 
-"type: bugfix":
+'type: bugfix':
   - head-branch:
-      - "^fix[/-]"
-      - "^bugfix[/-]"
-      - "^hotfix[/-]"
+      - '^fix[/-]'
+      - '^bugfix[/-]'
+      - '^hotfix[/-]'
 
-"type: refactor":
+'type: refactor':
   - head-branch:
-      - "^refactor[/-]"
-      - "^chore/refactor[/-]"
+      - '^refactor[/-]'
+      - '^chore/refactor[/-]'
 
-"type: chore":
+'type: chore':
   - head-branch:
-      - "^chore[/-]"
-      - "^build[/-]"
-      - "^ci[/-]"
+      - '^chore[/-]'
+      - '^build[/-]'
+      - '^ci[/-]'
 
-"type: docs":
+'type: docs':
   - head-branch:
-      - "^docs[/-]"
+      - '^docs[/-]'
   - changed-files:
       - any-glob-to-any-file:
-          - "README.md"
-          - "CONTRIBUTING.md"
-          - "AGENTS.md"
-          - "CHANGELOG.md"
-          - "SECURITY.md"
-          - "CODE_OF_CONDUCT.md"
-          - "docs/**"
+          - 'README.md'
+          - 'CONTRIBUTING.md'
+          - 'AGENTS.md'
+          - 'CHANGELOG.md'
+          - 'SECURITY.md'
+          - 'CODE_OF_CONDUCT.md'
+          - 'docs/**'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -17,6 +17,6 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Problem
The labeler.yml file had invalid YAML syntax with unquoted label names containing colons:
- `area: agents:` → YAML syntax error
- The GitHub Actions workflow `actions/labeler@v4` failed with: `YAMLException: bad indentation of a mapping entry`

## Solution
Quoted all label names that contain colons to be valid YAML:
- `area: agents:` → `"area: agents":`
- `type: feature:` → `"type: feature":`
- And all similar labels

## Changes
- Updated `.github/labeler.yml` with properly quoted label names
- Fixed regex patterns for branch matching (e.g., `^feat[/-]` instead of `^feat(/|-)`)

## Testing
The labeler workflow will now parse the YAML correctly and apply labels to PRs based on:
- Changed files (area labels)
- Branch name prefixes (type labels)

## Impact
- Fixes PR labeling automation
- Unblocks PR #10 labeler workflow
- Enables proper PR categorization for all future PRs