### PR TITLE
Add orchestration tests and release metadata baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [0.1.1]
+
 ### Added
 - Expanded automated test coverage for agent orchestration flows:
   - Shared finding round normalization and confidence filtering
@@ -14,8 +16,6 @@ All notable changes to this project are documented in this file.
 
 ### Changed
 - Updated package baseline version to 0.1.1 for release alignment.
-
-## [0.1.1]
 
 ### Notes
 - Baseline release marker used for current project state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [Unreleased]
+
+### Added
+- Expanded automated test coverage for agent orchestration flows:
+  - Shared finding round normalization and confidence filtering
+  - Review round fan-out and model override behavior
+  - Debate round transcript progression
+  - Principal synthesis schema handling
+- Added package metadata for repository links, issue tracking, and discoverability.
+
+### Changed
+- Updated package baseline version to 0.1.1 for release alignment.
+
+## [0.1.1]
+
+### Notes
+- Baseline release marker used for current project state.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,27 @@
 {
   "name": "swarm-review",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
+  "description": "GitHub Action that runs a multi-agent pull request review swarm with structured debate and principal synthesis.",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/EvanGribar/Swarm-Review.git"
+  },
+  "homepage": "https://github.com/EvanGribar/Swarm-Review#readme",
+  "bugs": {
+    "url": "https://github.com/EvanGribar/Swarm-Review/issues"
+  },
+  "keywords": [
+    "github-action",
+    "pull-request",
+    "code-review",
+    "llm",
+    "ai-agents",
+    "anthropic"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/src/tests/agents.debate.test.ts
+++ b/src/tests/agents.debate.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runDebateRounds } from "../agents/debate.js";
+import type { AgentConfig, FileDiff, Finding } from "../types.js";
+
+test("runDebateRounds appends each debate round to transcript", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const responses = [
+    [
+      {
+        agent: "security",
+        severity: "warning",
+        file: "src/app.ts",
+        line: 6,
+        claim: "Input validation should be centralized.",
+        confidence: 0.88,
+        rebuttal_to: "review-security-1",
+      },
+    ],
+    [],
+  ];
+
+  globalThis.fetch = (async () => {
+    const payload = responses.shift() ?? [];
+    return new Response(
+      JSON.stringify({ content: [{ type: "text", text: JSON.stringify(payload) }] }),
+      { status: 200 }
+    );
+  }) as typeof fetch;
+
+  const agents: AgentConfig[] = [{ name: "security", mandate: "Focus on security." }];
+  const diff: FileDiff[] = [
+    {
+      path: "src/app.ts",
+      status: "modified",
+      additions: 8,
+      deletions: 3,
+      changes: 11,
+      patch: "@@ -1,1 +1,2 @@",
+    },
+  ];
+  const initialFindings: Finding[] = [
+    {
+      id: "review-security-1",
+      agent: "security",
+      severity: "blocking",
+      file: "src/app.ts",
+      line: 4,
+      claim: "User input reaches SQL layer unsafely.",
+      confidence: 0.93,
+    },
+  ];
+
+  const transcript = await runDebateRounds({
+    agents,
+    diff,
+    initialFindings,
+    rounds: 2,
+    apiKey: "test-key",
+    model: "global-model",
+    minConfidence: 0.6,
+  });
+
+  assert.equal(transcript.rounds.length, 3);
+  assert.equal(transcript.rounds[0]?.length, 1);
+  assert.equal(transcript.rounds[1]?.length, 1);
+  assert.equal(transcript.rounds[2]?.length, 0);
+  assert.equal(transcript.rounds[1]?.[0]?.id, "debate-1-security-1");
+});

--- a/src/tests/agents.principal.test.ts
+++ b/src/tests/agents.principal.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { synthesizePrincipalSummary } from "../agents/principal.js";
+import type { DebateTranscript } from "../types.js";
+
+test("synthesizePrincipalSummary returns validated principal summary", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const finding = {
+    id: "review-security-1",
+    agent: "security",
+    severity: "blocking",
+    file: "src/auth.ts",
+    line: 17,
+    claim: "User input is not escaped before query composition.",
+    confidence: 0.94,
+  } as const;
+
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              agreements: [finding],
+              disputes: [],
+              final_calls: [{ finding, decision: "Blocking until query is parameterized." }],
+              summary: "## swarm-review\n\nPrincipal summary.",
+            }),
+          },
+        ],
+      }),
+      { status: 200 }
+    )) as typeof fetch;
+
+  const transcript: DebateTranscript = {
+    agents: [{ name: "security", mandate: "Find security risks." }],
+    rounds: [[finding]],
+  };
+
+  const summary = await synthesizePrincipalSummary({
+    principal: {
+      mandate: "Make final calls.",
+    },
+    transcript,
+    apiKey: "test-key",
+    model: "test-model",
+  });
+
+  assert.equal(summary.agreements.length, 1);
+  assert.equal(summary.final_calls.length, 1);
+  assert.match(summary.summary, /swarm-review/);
+});

--- a/src/tests/agents.review.test.ts
+++ b/src/tests/agents.review.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runReviewRound } from "../agents/review.js";
+import type { AgentConfig, FileDiff } from "../types.js";
+
+test("runReviewRound fans out to all agents and uses model overrides", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const requestBodies: Array<{ model?: string }> = [];
+  const responses = [
+    [
+      {
+        agent: "security",
+        severity: "blocking",
+        file: "src/db.ts",
+        line: 22,
+        claim: "Raw input is interpolated in SQL query text.",
+        confidence: 0.9,
+      },
+    ],
+    [
+      {
+        agent: "performance",
+        severity: "warning",
+        file: "src/api.ts",
+        line: 13,
+        claim: "Repeated parsing inside loop can be memoized.",
+        confidence: 0.82,
+      },
+    ],
+  ];
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBodies.push(JSON.parse(String(init?.body ?? "{}")) as { model?: string });
+    const payload = responses.shift() ?? [];
+
+    return new Response(
+      JSON.stringify({
+        content: [{ type: "text", text: JSON.stringify(payload) }],
+      }),
+      { status: 200 }
+    );
+  }) as typeof fetch;
+
+  const agents: AgentConfig[] = [
+    { name: "security", mandate: "Find security issues." },
+    { name: "performance", mandate: "Find performance issues.", model: "agent-model" },
+  ];
+  const diff: FileDiff[] = [
+    {
+      path: "src/db.ts",
+      status: "modified",
+      additions: 4,
+      deletions: 1,
+      changes: 5,
+      patch: "@@ -1,1 +1,1 @@",
+    },
+  ];
+
+  const findings = await runReviewRound({
+    agents,
+    diff,
+    apiKey: "test-key",
+    model: "global-model",
+    minConfidence: 0.6,
+  });
+
+  assert.equal(findings.length, 2);
+  assert.deepEqual(
+    requestBodies.map((body) => body.model).sort(),
+    ["agent-model", "global-model"].sort()
+  );
+  assert.match(findings[0]?.id ?? "", /^review-(security|performance)-1$/);
+});

--- a/src/tests/agents.shared.test.ts
+++ b/src/tests/agents.shared.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runAgentFindingRound } from "../agents/shared.js";
+
+test("runAgentFindingRound normalizes findings and filters by confidence", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify([
+              {
+                agent: "   ",
+                severity: "warning",
+                file: "src/auth.ts",
+                line: 8,
+                claim: "Token parsing should validate issuer.",
+                confidence: 0.8,
+              },
+              {
+                agent: "security",
+                severity: "suggestion",
+                file: "src/auth.ts",
+                line: 19,
+                claim: "Consider centralizing token expiry handling.",
+                confidence: 0.2,
+              },
+            ]),
+          },
+        ],
+      }),
+      { status: 200 }
+    )) as typeof fetch;
+
+  const findings = await runAgentFindingRound({
+    apiKey: "test-key",
+    model: "test-model",
+    system: "test-system",
+    prompt: "test-prompt",
+    agentName: "fallback-agent",
+    idPrefix: "review-fallback",
+    minConfidence: 0.5,
+  });
+
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0]?.id, "review-fallback-1");
+  assert.equal(findings[0]?.agent, "fallback-agent");
+});

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -1,3 +1,7 @@
 import "./config.test.js";
+import "./agents.debate.test.js";
+import "./agents.principal.test.js";
+import "./agents.review.test.js";
+import "./agents.shared.test.js";
 import "./format.test.js";
 import "./llm.test.js";


### PR DESCRIPTION
## Summary
This PR starts the v0.2 implementation with reliability and release hygiene groundwork.

### Included
- Add new tests for:
  - shared agent finding normalization/filtering
  - review fan-out behavior and model override handling
  - debate transcript round progression
  - principal synthesis schema handling
- Wire new tests into the test entrypoint
- Add a changelog scaffold with an Unreleased section
- Align package baseline to 0.1.1 and add package metadata links/keywords

## Why
This improves confidence in the core review/debate/synthesis flow and sets up cleaner release mechanics for the v0.2 cycle.

## Validation
- `npm test` passes locally
