### PR TITLE
Fix release action packaging and workflow validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,9 @@ jobs:
 
       - name: Test
         run: npm test
+
+      - name: Bundle action
+        run: npm run bundle
+
+      - name: Verify committed action bundle
+        run: git diff --exit-code -- dist/

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -28,14 +30,14 @@ jobs:
           npm run build
 
       - name: Skip swarm-review when API key is missing
-        if: ${{ secrets.ANTHROPIC_API_KEY == '' }}
+        if: ${{ env.ANTHROPIC_API_KEY == '' }}
         run: echo "Skipping swarm-review-example because ANTHROPIC_API_KEY is not configured."
 
       - name: Run swarm-review
-        if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        if: ${{ env.ANTHROPIC_API_KEY != '' }}
         uses: ./
         with:
           github-token: ${{ github.token }}
-          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic-api-key: ${{ env.ANTHROPIC_API_KEY }}
           anthropic-model: claude-3-5-sonnet-latest
           config-path: .swarm.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
-dist/
+dist/*
+!dist/index.js
 .DS_Store
 npm-debug.log*
 *.tsbuildinfo

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.13.10",
+        "@vercel/ncc": "^0.38.4",
         "typescript": "^5.8.2"
       }
     },
@@ -218,6 +219,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.38.4",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.4.tgz",
+      "integrity": "sha512-8LwjnlP39s08C08J5NstzriPvW1SP8Zfpp1BvC2sI35kPeZnHfxVkCwu4/+Wodgnd60UtT1n8K8zw+Mp7J9JmQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
       }
     },
     "node_modules/argparse": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "GitHub Action that runs a multi-agent pull request review swarm with structured debate and principal synthesis.",
   "license": "MIT",
-  "type": "module",
+  "type": "commonjs",
   "main": "dist/index.js",
   "repository": {
     "type": "git",
@@ -24,6 +24,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "bundle": "npm run typecheck && ncc build src/index.ts -o dist --minify",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "npm run build && node --test dist/tests/index.js"
   },
@@ -33,8 +34,9 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "@types/node": "^22.13.10",
     "@types/js-yaml": "^4.0.9",
+    "@types/node": "^22.13.10",
+    "@vercel/ncc": "^0.38.4",
     "typescript": "^5.8.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
     "rootDir": "src",
     "outDir": "dist",
     "types": ["node"],


### PR DESCRIPTION
## What changed
- bundle the TypeScript action and all runtime dependencies into committed `dist/index.js` with `@vercel/ncc`
- make CI regenerate the action bundle and fail when it is stale
- emit CommonJS so the bundled TypeScript compiler works under the GitHub Actions Node runtime
- move the example workflow secret into job-level `env` so its `if` conditions are valid

## Why
Published tags currently omit `dist/index.js` even though `action.yml` points to it, so external consumers cannot run the action. The example workflow also fails validation before creating any jobs because it references `secrets` directly in step conditions.

## Validation
- `npm test` (46 passing)
- `npm run typecheck`
- `npm run bundle`
- executed `node dist/index.js`; the bundle loaded successfully and reached the expected missing-token validation
- `git diff --check`