### PR TITLE
Add per-agent prompts and confidence thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Per-agent `system_prompt` instructions for specialized reviewer personalities while preserving built-in output guardrails.
+- Per-agent `min_confidence` thresholds, falling back to the global debate threshold when omitted.
+
 ## v0.7.0 - 2026-05-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ agents:
     mandate: >
       Review for security vulnerabilities. Look for injection risks, exposed secrets,
       broken auth, insecure defaults, and unsafe data handling.
+    system_prompt: >
+      You are a skeptical application-security reviewer. Prefer concrete exploit paths
+      over speculative concerns.
+    min_confidence: 0.8
     include_patterns: ["src/**"]
     exclude_patterns: ["*.spec.ts"]
 
@@ -170,7 +174,9 @@ principal: blocking until this path uses parameterized queries.
 ### Config fields
 
 - `provider`: optional LLM provider configuration (see Provider Configuration below).
-- `agents`: list of reviewer agents, each with a `name`, `mandate`, optional `model`, and optional agent-level file filters:
+- `agents`: list of reviewer agents, each with a `name`, `mandate`, and optional agent-level overrides:
+  - `agents[].system_prompt`: custom reviewer instructions appended to the built-in structured-output prompt.
+  - `agents[].min_confidence`: confidence threshold from `0` to `1`. Defaults to `debate.min_confidence`.
   - `agents[].include_patterns`: glob patterns of files this agent should review.
   - `agents[].exclude_patterns`: glob patterns of files this agent should ignore.
 - `debate.rounds`: how many debate rounds to run after the first-pass review.

--- a/src/agents/debate.ts
+++ b/src/agents/debate.ts
@@ -1,7 +1,7 @@
 import { buildDebatePrompt } from "../prompts.js";
 import { filterDiffForAgent } from "../diff.js";
 import type { AgentConfig, DebateTranscript, FileDiff, Finding, ProviderConfig, DiffConfig, ContextEnrichmentConfig } from "../types.js";
-import { runAgentFindingRound, resolveAgentProviderConfig } from "./shared.js";
+import { buildAgentSystemPrompt, runAgentFindingRound, resolveAgentProviderConfig } from "./shared.js";
 import { gatherContextForDiff, type IndexedSymbol } from "../context.js";
 
 export type DebateRoundInput = {
@@ -53,11 +53,11 @@ export async function runDebateRounds(input: DebateRoundInput): Promise<DebateTr
 
         return runAgentFindingRound({
           providerConfig,
-          system,
+          system: buildAgentSystemPrompt(system, agent.system_prompt),
           prompt: buildDebatePrompt(agent, filteredDiff, currentTranscript, debateRound, input.diffConfig, codeContext),
           agentName: agent.name,
           idPrefix: `debate-${debateRound}-${agent.name}`,
-          minConfidence: input.minConfidence,
+          minConfidence: agent.min_confidence ?? input.minConfidence,
         });
       })
     );

--- a/src/agents/review.ts
+++ b/src/agents/review.ts
@@ -1,7 +1,7 @@
 import { buildReviewPrompt } from "../prompts.js";
 import { filterDiffForAgent } from "../diff.js";
 import type { AgentConfig, FileDiff, Finding, ProviderConfig, DiffConfig, ContextEnrichmentConfig } from "../types.js";
-import { runAgentFindingRound, resolveAgentProviderConfig } from "./shared.js";
+import { buildAgentSystemPrompt, runAgentFindingRound, resolveAgentProviderConfig } from "./shared.js";
 import { gatherContextForDiff, type IndexedSymbol } from "../context.js";
 
 export type ReviewRoundInput = {
@@ -40,11 +40,11 @@ export async function runReviewRound(input: ReviewRoundInput): Promise<Finding[]
 
       return runAgentFindingRound({
         providerConfig,
-        system,
+        system: buildAgentSystemPrompt(system, agent.system_prompt),
         prompt: buildReviewPrompt(agent, filteredDiff, input.diffConfig, codeContext),
         agentName: agent.name,
         idPrefix: `review-${agent.name}`,
-        minConfidence: input.minConfidence,
+        minConfidence: agent.min_confidence ?? input.minConfidence,
       });
     })
   );

--- a/src/agents/shared.ts
+++ b/src/agents/shared.ts
@@ -42,3 +42,14 @@ export async function runAgentFindingRound(options: AgentRoundOptions): Promise<
     .map((finding, index) => normalizeFinding(finding, options.agentName, `${options.idPrefix}-${index + 1}`))
     .filter((finding) => finding.confidence >= options.minConfidence);
 }
+
+export function buildAgentSystemPrompt(
+  defaultSystemPrompt: string,
+  customSystemPrompt: string | undefined
+): string {
+  if (!customSystemPrompt) {
+    return defaultSystemPrompt;
+  }
+
+  return `${defaultSystemPrompt}\n\nAdditional agent instructions:\n${customSystemPrompt}`;
+}

--- a/src/tests/agents.debate.test.ts
+++ b/src/tests/agents.debate.test.ts
@@ -71,3 +71,81 @@ test("runDebateRounds appends each debate round to transcript", async (t) => {
   assert.equal(transcript.rounds[2]?.length, 0);
   assert.equal(transcript.rounds[1]?.[0]?.id, "debate-1-security-1");
 });
+
+test("runDebateRounds uses custom system prompt and agent-specific confidence threshold", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const requestBodies: Array<{ system?: string }> = [];
+  const responses = [
+    [
+      {
+        agent: "security",
+        severity: "warning",
+        file: "src/app.ts",
+        line: 6,
+        claim: "Debate round 1 security finding.",
+        confidence: 0.85,
+        rebuttal_to: "review-security-1",
+      },
+    ],
+    [],
+  ];
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBodies.push(JSON.parse(String(init?.body ?? "{}")) as { system?: string });
+    const payload = responses.shift() ?? [];
+    return new Response(
+      JSON.stringify({ content: [{ type: "text", text: JSON.stringify(payload) }] }),
+      { status: 200 }
+    );
+  }) as typeof fetch;
+
+  const agents: AgentConfig[] = [
+    {
+      name: "security",
+      mandate: "Focus on security.",
+      system_prompt: "Security debater prompt.",
+      min_confidence: 0.7,
+    },
+  ];
+  const diff: FileDiff[] = [
+    {
+      path: "src/app.ts",
+      status: "modified",
+      additions: 8,
+      deletions: 3,
+      changes: 11,
+      patch: "@@ -1,1 +1,2 @@",
+    },
+  ];
+  const initialFindings: Finding[] = [
+    {
+      id: "review-security-1",
+      agent: "security",
+      severity: "blocking",
+      file: "src/app.ts",
+      line: 4,
+      claim: "User input reaches SQL layer unsafely.",
+      confidence: 0.93,
+    },
+  ];
+
+  const transcript = await runDebateRounds({
+    agents,
+    diff,
+    initialFindings,
+    rounds: 1,
+    providerConfig: { type: "anthropic", config: { apiKey: "test-key", model: "global-model" } },
+    minConfidence: 0.6,
+  });
+
+  assert.equal(transcript.rounds.length, 2);
+  assert.equal(transcript.rounds[0]?.length, 1);
+  assert.equal(transcript.rounds[1]?.length, 1);
+  assert.equal(requestBodies.length, 1);
+  assert.match(requestBodies[0]?.system ?? "", /Return only JSON/);
+  assert.match(requestBodies[0]?.system ?? "", /Additional agent instructions:\nSecurity debater prompt\./);
+});

--- a/src/tests/agents.review.test.ts
+++ b/src/tests/agents.review.test.ts
@@ -75,3 +75,87 @@ test("runReviewRound fans out to all agents and uses model overrides", async (t)
   );
   assert.match(findings[0]?.id ?? "", /^review-(security|performance)-1$/);
 });
+
+test("runReviewRound uses custom system prompt and agent-specific confidence threshold", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const requestBodies: Array<{ system?: string }> = [];
+  const responses = [
+    [
+      {
+        agent: "security",
+        severity: "warning",
+        file: "src/db.ts",
+        line: 22,
+        claim: "Security warning.",
+        confidence: 0.85,
+      },
+    ],
+    [
+      {
+        agent: "performance",
+        severity: "suggestion",
+        file: "src/api.ts",
+        line: 13,
+        claim: "Performance suggestion.",
+        confidence: 0.55,
+      },
+    ],
+  ];
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBodies.push(JSON.parse(String(init?.body ?? "{}")) as { system?: string });
+    const payload = responses.shift() ?? [];
+
+    return new Response(
+      JSON.stringify({
+        content: [{ type: "text", text: JSON.stringify(payload) }],
+      }),
+      { status: 200 }
+    );
+  }) as typeof fetch;
+
+  const agents: AgentConfig[] = [
+    {
+      name: "security",
+      mandate: "Find security issues.",
+      system_prompt: "You are a top security researcher.",
+      min_confidence: 0.8,
+    },
+    {
+      name: "performance",
+      mandate: "Find performance issues.",
+      system_prompt: "You are a performance guru.",
+      min_confidence: 0.6, // Finding confidence is 0.55, so it should be filtered out!
+    },
+  ];
+  const diff: FileDiff[] = [
+    {
+      path: "src/db.ts",
+      status: "modified",
+      additions: 4,
+      deletions: 1,
+      changes: 5,
+      patch: "@@ -1,1 +1,1 @@",
+    },
+  ];
+
+  const findings = await runReviewRound({
+    agents,
+    diff,
+    providerConfig: { type: "anthropic", config: { apiKey: "test-key", model: "global-model" } },
+    minConfidence: 0.5, // global threshold is lower than both agents
+  });
+
+  // Only security finding should remain; performance was filtered out because confidence 0.55 < agent min_confidence 0.6
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0]?.agent, "security");
+  assert.equal(requestBodies.length, 2);
+  assert.match(requestBodies[0]?.system ?? "", /Return only JSON/);
+  assert.match(requestBodies[0]?.system ?? "", /Additional agent instructions:\nYou are a top security researcher\./);
+  assert.match(requestBodies[1]?.system ?? "", /Return only JSON/);
+  assert.match(requestBodies[1]?.system ?? "", /Additional agent instructions:\nYou are a performance guru\./);
+});

--- a/src/tests/config.test.ts
+++ b/src/tests/config.test.ts
@@ -22,6 +22,8 @@ test("loadSwarmConfig reads a local config file", async () => {
       "agents:",
       "  - name: custom",
       "    mandate: Review the change carefully.",
+      "    system_prompt: You are a custom system prompt.",
+      "    min_confidence: 0.85",
       "debate:",
       "  rounds: 1",
       "  min_confidence: 0.7",
@@ -36,6 +38,8 @@ test("loadSwarmConfig reads a local config file", async () => {
   const config = await loadSwarmConfig(tempDir);
 
   assert.equal(config.agents[0]?.name, "custom");
+  assert.equal(config.agents[0]?.system_prompt, "You are a custom system prompt.");
+  assert.equal(config.agents[0]?.min_confidence, 0.85);
   assert.equal(config.debate.rounds, 1);
   assert.equal(config.debate.min_confidence, 0.7);
   assert.equal(config.principal.mandate, "Make the final call.");

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,8 @@ export const AgentConfigSchema = z.object({
   name: z.string().min(1),
   mandate: z.string().min(1),
   model: z.string().min(1).optional(),
+  system_prompt: z.string().min(1).optional(),
+  min_confidence: z.number().min(0).max(1).optional(),
   include_patterns: z.array(z.string()).optional(),
   exclude_patterns: z.array(z.string()).optional(),
 });


### PR DESCRIPTION
## What changed
- add optional per-agent `system_prompt` configuration
- add optional per-agent `min_confidence` thresholds with global fallback
- apply both overrides consistently in initial review and debate rounds
- document the configuration and add release notes
- add coverage for parsing, provider requests, threshold filtering, and debate behavior

## Why
Teams need to tune reviewer personalities and noise thresholds independently. A single global prompt and threshold makes mixed specialist swarms either too generic or too noisy.

## Validation
- `npm ci`
- `npm test` (48 passing)
- `npm run typecheck`
- `git diff --check`