### PR TITLE
Add trusted conversational re-reviews

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -3,6 +3,8 @@ name: swarm-review-example
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
@@ -11,7 +13,17 @@ permissions:
 
 jobs:
   review:
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/swarm-review') &&
+      (github.event.comment.author_association == 'OWNER' ||
+      github.event.comment.author_association == 'MEMBER' ||
+      github.event.comment.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
+    concurrency:
+      group: swarm-review-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented in this file.
 ### Added
 - Per-agent `system_prompt` instructions for specialized reviewer personalities while preserving built-in output guardrails.
 - Per-agent `min_confidence` thresholds, falling back to the global debate threshold when omitted.
+- Trusted conversational re-reviews triggered by exact `/swarm-review` commands on pull requests.
+
+### Security
+- Restrict comment-triggered paid runs to repository owners, organization members, and collaborators.
+- Bound developer-feedback context and ignore spoofed managed-comment markers from non-bot users.
 
 ## v0.7.0 - 2026-05-21
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ name: swarm-review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
@@ -51,7 +53,17 @@ permissions:
 
 jobs:
   review:
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/swarm-review') &&
+      (github.event.comment.author_association == 'OWNER' ||
+      github.event.comment.author_association == 'MEMBER' ||
+      github.event.comment.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
+    concurrency:
+      group: swarm-review-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -66,6 +78,19 @@ jobs:
 ```
 
 Then add a `.swarm.yml` file at the repository root if you want to customize the swarm.
+
+### Conversational Re-Review
+
+When the `issue_comment` trigger is enabled, repository owners, organization members, and collaborators can reply with `/swarm-review` or `/swarm-review debate` on its own line to trigger a re-review. Commands from bots, outside contributors, and other users are ignored so public comments cannot spend the repository's model budget.
+
+During a re-review, the action:
+1. Gathers all comments posted after the latest principal's review comment.
+2. Identifies developer feedback (excluding the bot's own comments).
+3. Strips the trigger commands and feeds the text directly into the debate agent prompt.
+
+This allows agents to incorporate developer feedback and debate, defend, or concede their findings based on developer responses. The action bounds collected feedback to avoid unbounded prompt growth. If a comment does not contain an exact command, the action exits immediately without calling a model.
+
+For `issue_comment` events, keep the checkout on the trusted default branch. Checking out and executing code from an untrusted pull request in a workflow that can access secrets is unsafe. The pull request diff still comes from GitHub's API; local static-analysis and context-enrichment inputs come from the trusted checkout.
 
 ## Configuration
 
@@ -174,7 +199,7 @@ principal: blocking until this path uses parameterized queries.
 ### Config fields
 
 - `provider`: optional LLM provider configuration (see Provider Configuration below).
-- `agents`: list of reviewer agents, each with a `name`, `mandate`, and optional agent-level overrides:
+- `agents`: list of reviewer agents, each with a `name`, `mandate`, optional `model`, and optional agent-level overrides:
   - `agents[].system_prompt`: custom reviewer instructions appended to the built-in structured-output prompt.
   - `agents[].min_confidence`: confidence threshold from `0` to `1`. Defaults to `debate.min_confidence`.
   - `agents[].include_patterns`: glob patterns of files this agent should review.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,9 +7,9 @@ gantt
     title Swarm-Review Release Timeline
     dateFormat  YYYY-MM-DD
     section Future Milestones
-    v0.8.0 (Interactive Feedback & Agent Profiles) :active, 2026-07-06, 15d
-    v1.0.0 (Production Hardening & Cost Controls) : 2026-07-21, 20d
+    v1.0.0 (Production Hardening & Cost Controls) :active, 2026-07-21, 20d
     v1.1.0 (Integration Framework & Web UI Dashboard) : 2026-08-10, 20d
+    v1.2.0 (IDE Extensions & Advanced Context) : 2026-08-30, 20d
 ```
 
 ---
@@ -23,18 +23,6 @@ Our goal is to make **swarm-review** the premier open-source multi-agent PR revi
 ---
 
 ## 🚀 Milestones
-
-### 📍 Phase 3: Interactive Feedback Loops & Agent Tuning (v0.8.0)
-*Currently, the review is a one-way street. Users should be able to clarify questions, dispute findings, or instruct agents to re-evaluate their recommendations.*
-
-#### Proposed Features
-- **Conversational Re-Review**:
-  - Trigger reviews by replying directly to the principal's comment with a command (e.g., `/swarm-review debate`).
-  - Retrieve the comment thread from GitHub, parse the developer's inputs, and feed them back to the debate agent prompt.
-- **Custom Agent System Prompts**:
-  - Support setting a custom system prompt or "personality" override for each agent.
-- **Confidence Calibration**:
-  - Introduce fine-grained thresholds to prevent noise and ensure that suggestions are only highlighted if they exceed the target confidence.
 
 ---
 
@@ -82,6 +70,19 @@ static_analysis:
   - A lightweight local web app to view complex debates interactively, trace decision paths, and inspect code signatures side-by-side.
 - **Pluggable Agent Packages**:
   - Support importing third-party agent rosters and custom prompts from npm packages or external URLs.
+
+---
+
+### 📍 Phase 6: IDE Extensions & Advanced Context (v1.2.0)
+*Integrating review cycles directly into developers' inner-loop development workspaces.*
+
+#### Proposed Features
+- **VS Code & Cursor Extensions**:
+  - Run the review swarm locally on modified files directly inside the editor before committing/pushing.
+- **Language Server (LSP) Code Graph Context**:
+  - Parse deep dependency relationships across the entire codebase to understand the impact of PR changes globally.
+- **Branch-Specific Policy Rules**:
+  - Define customized rules and agent assignments depending on the target branch (e.g., stricter security checks on `release` or `main`).
 
 ---
 

--- a/src/agents/debate.ts
+++ b/src/agents/debate.ts
@@ -15,6 +15,7 @@ export type DebateRoundInput = {
   contextEnrichment?: ContextEnrichmentConfig;
   workspaceRoot?: string;
   codebaseIndex?: Map<string, IndexedSymbol>;
+  developerFeedback?: string[];
 };
 
 export async function runDebateRounds(input: DebateRoundInput): Promise<DebateTranscript> {
@@ -54,7 +55,7 @@ export async function runDebateRounds(input: DebateRoundInput): Promise<DebateTr
         return runAgentFindingRound({
           providerConfig,
           system: buildAgentSystemPrompt(system, agent.system_prompt),
-          prompt: buildDebatePrompt(agent, filteredDiff, currentTranscript, debateRound, input.diffConfig, codeContext),
+          prompt: buildDebatePrompt(agent, filteredDiff, currentTranscript, debateRound, input.diffConfig, codeContext, input.developerFeedback),
           agentName: agent.name,
           idPrefix: `debate-${debateRound}-${agent.name}`,
           minConfidence: agent.min_confidence ?? input.minConfidence,

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,35 @@
+const REREVIEW_COMMAND = /^\/swarm-review(?:\s+(debate))?$/i;
+const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
+export type RereviewCommand = "review" | "debate";
+
+export function parseRereviewCommand(body: string): RereviewCommand | undefined {
+  for (const line of body.split(/\r?\n/)) {
+    const match = line.trim().match(REREVIEW_COMMAND);
+    if (match) {
+      return match[1] ? "debate" : "review";
+    }
+  }
+
+  return undefined;
+}
+
+export function stripRereviewCommands(body: string): string {
+  return body
+    .split(/\r?\n/)
+    .filter((line) => !REREVIEW_COMMAND.test(line.trim()))
+    .join("\n")
+    .trim();
+}
+
+export function isTrustedRereviewActor(
+  authorAssociation: unknown,
+  userType: unknown
+): boolean {
+  const isBot = typeof userType === "string" && userType.toLowerCase() === "bot";
+  return (
+    !isBot &&
+    typeof authorAssociation === "string" &&
+    TRUSTED_ASSOCIATIONS.has(authorAssociation.toUpperCase())
+  );
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,6 +1,10 @@
 import type { Octokit } from "@octokit/rest";
+import { stripRereviewCommands } from "./events.js";
 
 const MANAGED_COMMENT_MARKER = "<!-- swarm-review:managed-comment -->";
+const MAX_FEEDBACK_COMMENTS = 20;
+const MAX_FEEDBACK_COMMENT_CHARS = 4_000;
+const MAX_FEEDBACK_TOTAL_CHARS = 20_000;
 
 export type UpsertPullRequestCommentResult = {
   action: "created" | "updated";
@@ -25,6 +29,20 @@ function withManagedCommentMarker(body: string): string {
   return `${body}\n\n${MANAGED_COMMENT_MARKER}`;
 }
 
+function isSwarmBotComment(
+  comment: { body?: string | null; user?: { type?: string; login?: string } | null },
+  botLogin: string | undefined
+): boolean {
+  const isAuthenticatedActor = botLogin
+    ? comment.user?.login === botLogin
+    : comment.user?.type?.toLowerCase() === "bot";
+
+  return Boolean(
+    isAuthenticatedActor &&
+      (comment.body?.includes(MANAGED_COMMENT_MARKER) || comment.body?.startsWith("## swarm-review"))
+  );
+}
+
 export async function upsertPullRequestComment(
   octokit: Octokit,
   owner: string,
@@ -46,12 +64,9 @@ export async function upsertPullRequestComment(
       .catch(() => null),
   ]);
 
-  const existingComment = [...comments].reverse().find(
-    (comment) =>
-      comment.body?.includes(MANAGED_COMMENT_MARKER) ||
-      (comment.body?.startsWith("## swarm-review") &&
-        (comment.user?.type === "Bot" || (authenticatedUser && comment.user?.login === authenticatedUser.login)))
-  );
+  const existingComment = [...comments]
+    .reverse()
+    .find((comment) => isSwarmBotComment(comment, authenticatedUser?.login));
 
   if (existingComment) {
     const response = await octokit.rest.issues.updateComment({
@@ -135,4 +150,65 @@ export async function createPullRequestReview(
       side: "RIGHT",
     })),
   });
+}
+
+export async function getDeveloperFeedback(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  pullNumber: number
+): Promise<string[]> {
+  const [comments, authenticatedUser] = await Promise.all([
+    octokit.paginate(octokit.rest.issues.listComments, {
+      owner,
+      repo,
+      issue_number: pullNumber,
+      per_page: 100,
+    }),
+    octokit.rest.users.getAuthenticated()
+      .then((res) => res.data)
+      .catch(() => null),
+  ]);
+
+  const botLogin = authenticatedUser?.login;
+
+  const latestBotCommentIndex = comments.reduce((latestIdx, comment, idx) => {
+    return isSwarmBotComment(comment, botLogin) ? idx : latestIdx;
+  }, -1);
+
+  if (latestBotCommentIndex === -1) {
+    return [];
+  }
+
+  const feedbackComments = comments
+    .slice(latestBotCommentIndex + 1)
+    .slice(-MAX_FEEDBACK_COMMENTS);
+  const developerFeedback: string[] = [];
+  let totalChars = 0;
+
+  for (const comment of feedbackComments) {
+    if (
+      comment.user?.type?.toLowerCase() === "bot" ||
+      Boolean(botLogin && comment.user?.login === botLogin)
+    ) {
+      continue;
+    }
+
+    const login = comment.user?.login ?? "developer";
+    const body = comment.body ?? "";
+    const cleanedBody = stripRereviewCommands(body).slice(0, MAX_FEEDBACK_COMMENT_CHARS);
+
+    if (cleanedBody.length > 0) {
+      const remainingChars = MAX_FEEDBACK_TOTAL_CHARS - totalChars;
+      if (remainingChars <= 0) {
+        break;
+      }
+
+      const entry = `[${login}]: ${cleanedBody}`.slice(0, remainingChars);
+      developerFeedback.push(entry);
+      totalChars += entry.length;
+    }
+  }
+
+  return developerFeedback;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,13 +6,23 @@ import { loadSwarmConfig, readInput, resolveProviderConfig } from "./config.js";
 import { runDebateRounds } from "./agents/debate.js";
 import { runReviewRound } from "./agents/review.js";
 import { synthesizePrincipalSummary } from "./agents/principal.js";
-import { upsertPullRequestComment, updateCheckRun, parsePositiveInteger, createPullRequestReview } from "./github.js";
+import { upsertPullRequestComment, updateCheckRun, parsePositiveInteger, createPullRequestReview, getDeveloperFeedback } from "./github.js";
 import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_API_ENDPOINT } from "./llm.js";
 import { renderDebateTranscriptMarkdown, formatInlineCommentBody } from "./format.js";
 import { runStaticAnalysis } from "./static_analysis.js";
 import { DEFAULT_PROVIDER_CONFIG, type ProviderConfig, type SwarmConfig, type Finding } from "./types.js";
 import { tokenTracker, resetTokenTracker, calculateEstimatedCost } from "./providers.js";
 import { buildCodebaseIndex } from "./context.js";
+import { isTrustedRereviewActor, parseRereviewCommand } from "./events.js";
+
+type IssueCommentEventPayload = {
+  issue?: { pull_request?: unknown };
+  comment?: {
+    body?: unknown;
+    author_association?: unknown;
+    user?: { type?: unknown };
+  };
+};
 
 
 
@@ -97,6 +107,47 @@ function buildStatsBlock(): string {
   ].join("\n");
 }
 async function main(): Promise<void> {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  const eventName = process.env.GITHUB_EVENT_NAME;
+  let eventPayload: IssueCommentEventPayload | null = null;
+  if (eventPath && existsSync(eventPath)) {
+    try {
+      eventPayload = JSON.parse(await readFile(eventPath, "utf8")) as IssueCommentEventPayload;
+    } catch {
+      // Ignore
+    }
+  }
+
+  if (eventName === "issue_comment") {
+    const isPR = eventPayload?.issue?.pull_request !== undefined;
+    if (!isPR) {
+      console.log("Triggered by issue_comment but not on a pull request. Skipping swarm-review.");
+      return;
+    }
+
+    const comment = eventPayload?.comment;
+    const command =
+      typeof comment?.body === "string"
+        ? parseRereviewCommand(comment.body)
+        : undefined;
+    if (!command) {
+      console.log("Comment does not contain an exact '/swarm-review' command. Skipping swarm-review.");
+      return;
+    }
+
+    if (
+      !isTrustedRereviewActor(
+        comment?.author_association,
+        comment?.user?.type
+      )
+    ) {
+      console.log("The re-review command author is not a repository owner, member, or collaborator. Skipping swarm-review.");
+      return;
+    }
+
+    console.log(`Triggered by trusted conversational re-review command (${command}).`);
+  }
+
   const githubToken = readInput("github-token") ?? process.env.GITHUB_TOKEN;
   const anthropicApiKey = readInput("anthropic-api-key") ?? process.env.ANTHROPIC_API_KEY;
   const anthropicModel = readInput("anthropic-model") ?? process.env.ANTHROPIC_MODEL ?? DEFAULT_ANTHROPIC_MODEL;
@@ -141,6 +192,16 @@ async function main(): Promise<void> {
 
   const combinedFindings = [...reviewFindings, ...linterFindings];
 
+  let developerFeedback: string[] = [];
+  try {
+    developerFeedback = await getDeveloperFeedback(octokit, owner, repo, pullNumber);
+    if (developerFeedback.length > 0) {
+      console.log(`Gathered ${developerFeedback.length} developer comment(s) from thread.`);
+    }
+  } catch (error) {
+    console.log(`Warning: Failed to fetch developer feedback: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
   const transcript = await runDebateRounds({
     agents: swarmConfig.agents,
     diff,
@@ -152,6 +213,7 @@ async function main(): Promise<void> {
     contextEnrichment: swarmConfig.context_enrichment,
     workspaceRoot,
     codebaseIndex,
+    developerFeedback,
   });
 
   const summary = await synthesizePrincipalSummary({

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -39,7 +39,8 @@ export function buildDebatePrompt(
   transcript: DebateTranscript,
   debateRound: number,
   diffConfig?: DiffConfig,
-  codeContext?: string
+  codeContext?: string,
+  developerFeedback?: string[]
 ): string {
   const parts = [
     `Agent name: ${agent.name}`,
@@ -49,6 +50,12 @@ export function buildDebatePrompt(
 
   if (codeContext && codeContext.trim()) {
     parts.push(codeContext.trim());
+  }
+
+  if (developerFeedback && developerFeedback.length > 0) {
+    parts.push(
+      `Developer feedback and inputs:\n${developerFeedback.map((f) => `- ${f}`).join("\n")}`
+    );
   }
 
   parts.push(

--- a/src/tests/agents.debate.test.ts
+++ b/src/tests/agents.debate.test.ts
@@ -78,7 +78,7 @@ test("runDebateRounds uses custom system prompt and agent-specific confidence th
     globalThis.fetch = originalFetch;
   });
 
-  const requestBodies: Array<{ system?: string }> = [];
+  const requestBodies: Array<{ system?: string; messages?: Array<{ content?: string }> }> = [];
   const responses = [
     [
       {
@@ -95,7 +95,7 @@ test("runDebateRounds uses custom system prompt and agent-specific confidence th
   ];
 
   globalThis.fetch = (async (_input, init) => {
-    requestBodies.push(JSON.parse(String(init?.body ?? "{}")) as { system?: string });
+    requestBodies.push(JSON.parse(String(init?.body ?? "{}")) as { system?: string; messages?: Array<{ content?: string }> });
     const payload = responses.shift() ?? [];
     return new Response(
       JSON.stringify({ content: [{ type: "text", text: JSON.stringify(payload) }] }),
@@ -140,6 +140,7 @@ test("runDebateRounds uses custom system prompt and agent-specific confidence th
     rounds: 1,
     providerConfig: { type: "anthropic", config: { apiKey: "test-key", model: "global-model" } },
     minConfidence: 0.6,
+    developerFeedback: ["[alice]: Please recheck line 22"],
   });
 
   assert.equal(transcript.rounds.length, 2);
@@ -148,4 +149,6 @@ test("runDebateRounds uses custom system prompt and agent-specific confidence th
   assert.equal(requestBodies.length, 1);
   assert.match(requestBodies[0]?.system ?? "", /Return only JSON/);
   assert.match(requestBodies[0]?.system ?? "", /Additional agent instructions:\nSecurity debater prompt\./);
+  assert.match(requestBodies[0]?.messages?.[0]?.content ?? "", /Developer feedback and inputs:/);
+  assert.match(requestBodies[0]?.messages?.[0]?.content ?? "", /- \[alice\]: Please recheck line 22/);
 });

--- a/src/tests/events.test.ts
+++ b/src/tests/events.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isTrustedRereviewActor,
+  parseRereviewCommand,
+  stripRereviewCommands,
+} from "../events.js";
+
+test("parseRereviewCommand accepts exact command lines", () => {
+  assert.equal(parseRereviewCommand("/swarm-review"), "review");
+  assert.equal(parseRereviewCommand("  /SWARM-REVIEW debate  \nPlease retry."), "debate");
+
+  assert.equal(parseRereviewCommand("please /swarm-review"), undefined);
+  assert.equal(parseRereviewCommand("/swarm-reviewer"), undefined);
+  assert.equal(parseRereviewCommand("/swarm-review debate now"), undefined);
+});
+
+test("stripRereviewCommands removes only command lines", () => {
+  assert.equal(
+    stripRereviewCommands("/swarm-review debate\nPlease revisit auth.\nMention /swarm-review literally."),
+    "Please revisit auth.\nMention /swarm-review literally."
+  );
+});
+
+test("isTrustedRereviewActor restricts paid runs to trusted humans", () => {
+  assert.equal(isTrustedRereviewActor("OWNER", "User"), true);
+  assert.equal(isTrustedRereviewActor("member", "User"), true);
+  assert.equal(isTrustedRereviewActor("COLLABORATOR", "User"), true);
+  assert.equal(isTrustedRereviewActor("CONTRIBUTOR", "User"), false);
+  assert.equal(isTrustedRereviewActor("NONE", "User"), false);
+  assert.equal(isTrustedRereviewActor("MEMBER", "Bot"), false);
+  assert.equal(isTrustedRereviewActor("MEMBER", "bot"), false);
+});

--- a/src/tests/github.test.ts
+++ b/src/tests/github.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { parsePositiveInteger, upsertPullRequestComment, updateCheckRun } from "../github.js";
+import { parsePositiveInteger, upsertPullRequestComment, updateCheckRun, getDeveloperFeedback } from "../github.js";
 
 type MockComment = {
   id: number;
@@ -79,6 +79,36 @@ test("upsertPullRequestComment creates new comment when no swarm comment exists"
   assert.match(String(state.created[0]?.body), /new body/);
 });
 
+test("upsertPullRequestComment ignores spoofed managed markers from users", async () => {
+  const { octokit, state } = createOctokitMock([
+    {
+      id: 1,
+      body: "## swarm-review\n\nspoof\n\n<!-- swarm-review:managed-comment -->",
+      user: { type: "User", login: "attacker" },
+    },
+  ]);
+
+  await upsertPullRequestComment(octokit as never, "owner", "repo", 12, "## swarm-review\n\nnew body");
+
+  assert.equal(state.updated.length, 0);
+  assert.equal(state.created.length, 1);
+});
+
+test("upsertPullRequestComment ignores managed markers from other bots", async () => {
+  const { octokit, state } = createOctokitMock([
+    {
+      id: 1,
+      body: "## swarm-review\n\nspoof\n\n<!-- swarm-review:managed-comment -->",
+      user: { type: "Bot", login: "other-bot" },
+    },
+  ]);
+
+  await upsertPullRequestComment(octokit as never, "owner", "repo", 12, "## swarm-review\n\nnew body");
+
+  assert.equal(state.updated.length, 0);
+  assert.equal(state.created.length, 1);
+});
+
 test("updateCheckRun ignores non-numeric IDs and updates numeric IDs", async () => {
   const { octokit, state } = createOctokitMock();
 
@@ -106,4 +136,80 @@ test("parsePositiveInteger accepts only positive integer strings", () => {
   assert.equal(parsePositiveInteger(""), undefined);
   assert.equal(parsePositiveInteger(" 42 "), undefined);
   assert.equal(parsePositiveInteger("9007199254740992"), undefined);
+});
+
+test("getDeveloperFeedback gathers, filters, and formats comments after the latest bot comment", async () => {
+  const { octokit } = createOctokitMock([
+    {
+      id: 1,
+      body: "early developer comment - should be ignored",
+      user: { type: "User", login: "alice" },
+    },
+    {
+      id: 2,
+      body: "## swarm-review\n\nbot summary comment\n\n<!-- swarm-review:managed-comment -->",
+      user: { type: "User", login: "swarm-bot" },
+    },
+    {
+      id: 3,
+      body: "another bot reply - should be ignored",
+      user: { type: "User", login: "swarm-bot" },
+    },
+    {
+      id: 4,
+      body: "/swarm-review debate\nWait, check line 24. Security agent is incorrect.",
+      user: { type: "User", login: "bob" },
+    },
+    {
+      id: 5,
+      body: "   /swarm-review   ",
+      user: { type: "User", login: "charlie" }, // should be cleaned to empty and ignored
+    },
+    {
+      id: 6,
+      body: "I agree with Bob.",
+      user: { type: "User", login: "alice" },
+    },
+  ]);
+
+  const feedback = await getDeveloperFeedback(octokit as never, "owner", "repo", 12);
+
+  assert.equal(feedback.length, 2);
+  assert.equal(feedback[0], "[bob]: Wait, check line 24. Security agent is incorrect.");
+  assert.equal(feedback[1], "[alice]: I agree with Bob.");
+});
+
+test("getDeveloperFeedback returns empty if no bot comment is found", async () => {
+  const { octokit } = createOctokitMock([
+    {
+      id: 1,
+      body: "early developer comment",
+      user: { type: "User", login: "alice" },
+    },
+  ]);
+
+  const feedback = await getDeveloperFeedback(octokit as never, "owner", "repo", 12);
+  assert.equal(feedback.length, 0);
+});
+
+test("getDeveloperFeedback bounds comment count and total prompt size", async () => {
+  const comments: MockComment[] = [
+    {
+      id: 1,
+      body: "## swarm-review\n\nsummary\n\n<!-- swarm-review:managed-comment -->",
+      user: { type: "User", login: "swarm-bot" },
+    },
+    ...Array.from({ length: 25 }, (_, index) => ({
+      id: index + 2,
+      body: "x".repeat(5_000),
+      user: { type: "User", login: `user-${index}` },
+    })),
+  ];
+  const { octokit } = createOctokitMock(comments);
+
+  const feedback = await getDeveloperFeedback(octokit as never, "owner", "repo", 12);
+
+  assert.ok(feedback.length <= 20);
+  assert.ok(feedback.reduce((total, entry) => total + entry.length, 0) <= 20_000);
+  assert.match(feedback[0] ?? "", /^\[user-5\]:/);
 });

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -4,6 +4,7 @@ import "./agents.principal.test.js";
 import "./agents.review.test.js";
 import "./agents.shared.test.js";
 import "./diff.test.js";
+import "./events.test.js";
 import "./format.test.js";
 import "./github.test.js";
 import "./llm.test.js";

--- a/src/tests/prompts.test.ts
+++ b/src/tests/prompts.test.ts
@@ -58,6 +58,17 @@ test("buildDebatePrompt includes round and prior transcript", () => {
   assert.match(prompt, /review-security-1/);
 });
 
+test("buildDebatePrompt includes developer feedback if provided", () => {
+  const prompt = buildDebatePrompt(agent, diff, transcript, 2, undefined, undefined, [
+    "[alice]: Please recheck line 22",
+    "[bob]: Yes, agreed",
+  ]);
+
+  assert.match(prompt, /Developer feedback and inputs:/);
+  assert.match(prompt, /- \[alice\]: Please recheck line 22/);
+  assert.match(prompt, /- \[bob\]: Yes, agreed/);
+});
+
 test("buildPrincipalPrompt includes transcript and principal contract instruction", () => {
   const prompt = buildPrincipalPrompt(principal, transcript);
 


### PR DESCRIPTION
## What changed
- add `/swarm-review` and `/swarm-review debate` comment-triggered re-reviews
- collect bounded developer feedback after the latest managed review and include it in debate prompts
- restrict paid comment-triggered runs to owners, members, and collaborators
- require exact command lines and ignore bot triggers
- prevent spoofed managed-comment markers from hijacking comment updates or feedback boundaries
- add workflow-level authorization and per-PR concurrency cancellation
- document safe `issue_comment` checkout behavior and update the roadmap

## Why
Review findings need an interactive correction loop, but public issue comments must not be able to spend model credits or cause secret-bearing workflows to execute pull-request code.

## Validation
- `npm test` (56 passing)
- `npm run typecheck`
- `git diff --check`

## Stack
This PR is based on #59 because it extends the per-agent customization changes already present in the original feature branch. Retarget it to `main` after #59 merges.