### PR TITLE
Add strict per-run model budget controls

### DIFF
--- a/.swarm.yml
+++ b/.swarm.yml
@@ -7,6 +7,14 @@ provider:
     apiKey: $ANTHROPIC_API_KEY  # Or use a GitHub secret
     model: claude-3-5-sonnet-latest
 
+# Optional strict worst-case spend cap for all model calls in one action run.
+# Calls use fallback_model when the primary model no longer fits; calls are skipped
+# before the cap can be exceeded when neither model fits.
+# budget:
+#   max_cost_usd: 1.50
+#   fallback_model: claude-3-5-haiku-latest
+#   max_output_tokens: 4096
+
 # Alternative: OpenAI
 # provider:
 #   type: openai

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project are documented in this file.
 - Per-agent `system_prompt` instructions for specialized reviewer personalities while preserving built-in output guardrails.
 - Per-agent `min_confidence` thresholds, falling back to the global debate threshold when omitted.
 - Trusted conversational re-reviews triggered by exact `/swarm-review` commands on pull requests.
-- Strict per-run model budgets with concurrency-safe worst-case reservations, configurable output caps, and same-provider fallback models.
+- Strict per-run model budgets with concurrency-safe reservations, successful-call settlement, configurable output caps, and same-provider fallback models.
 - Budget-aware degradation that skips unaffordable reviewer calls, defers unsynthesized findings for manual review, and prevents automatic approval after exhaustion.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project are documented in this file.
 - Per-agent `system_prompt` instructions for specialized reviewer personalities while preserving built-in output guardrails.
 - Per-agent `min_confidence` thresholds, falling back to the global debate threshold when omitted.
 - Trusted conversational re-reviews triggered by exact `/swarm-review` commands on pull requests.
+- Strict per-run model budgets with concurrency-safe worst-case reservations, configurable output caps, and same-provider fallback models.
+- Budget-aware degradation that skips unaffordable reviewer calls, defers unsynthesized findings for manual review, and prevents automatic approval after exhaustion.
 
 ### Security
 - Restrict comment-triggered paid runs to repository owners, organization members, and collaborators.

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ principal: blocking until this path uses parameterized queries.
   - `agents[].min_confidence`: confidence threshold from `0` to `1`. Defaults to `debate.min_confidence`.
   - `agents[].include_patterns`: glob patterns of files this agent should review.
   - `agents[].exclude_patterns`: glob patterns of files this agent should ignore.
-- `budget.max_cost_usd`: optional strict per-run spend cap. Before every call, swarm-review reserves a conservative worst-case cost and never starts a call that would exceed the cap.
+- `budget.max_cost_usd`: optional strict per-run spend cap. Before every call, swarm-review reserves a conservative worst-case cost and never starts a call that would exceed the cap. Successful calls settle to an observed-output upper bound; failed or ambiguous calls retain their reservation because they may still be billable.
 - `budget.fallback_model`: optional cheaper model from the same provider to use when the primary model no longer fits. Models without known pricing require a known fallback when budgeting is enabled.
 - `budget.max_output_tokens`: maximum output tokens reserved and requested per call. Defaults to `4096`.
 - `debate.rounds`: how many debate rounds to run after the first-pass review.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ debate:
   rounds: 2
   min_confidence: 0.6
 
+budget:
+  max_cost_usd: 1.50
+  fallback_model: claude-3-5-haiku-latest
+  max_output_tokens: 4096
+
 principal:
   mandate: >
     You are the principal engineer. Read the full debate and make final calls.
@@ -204,6 +209,9 @@ principal: blocking until this path uses parameterized queries.
   - `agents[].min_confidence`: confidence threshold from `0` to `1`. Defaults to `debate.min_confidence`.
   - `agents[].include_patterns`: glob patterns of files this agent should review.
   - `agents[].exclude_patterns`: glob patterns of files this agent should ignore.
+- `budget.max_cost_usd`: optional strict per-run spend cap. Before every call, swarm-review reserves a conservative worst-case cost and never starts a call that would exceed the cap.
+- `budget.fallback_model`: optional cheaper model from the same provider to use when the primary model no longer fits. Models without known pricing require a known fallback when budgeting is enabled.
+- `budget.max_output_tokens`: maximum output tokens reserved and requested per call. Defaults to `4096`.
 - `debate.rounds`: how many debate rounds to run after the first-pass review.
 - `debate.min_confidence`: findings below this threshold are filtered out.
 - `principal.mandate`: instructions for the synthesis agent.

--- a/src/agents/principal.ts
+++ b/src/agents/principal.ts
@@ -1,6 +1,7 @@
 import { callLLMStructured } from "../llm.js";
 import { buildPrincipalPrompt } from "../prompts.js";
 import { PrincipalSummarySchema, type DebateTranscript, type PrincipalConfig, type PrincipalSummary, type ProviderConfig } from "../types.js";
+import { BudgetExceededError } from "../budget.js";
 
 export type PrincipalRoundInput = {
   principal: PrincipalConfig;
@@ -9,10 +10,30 @@ export type PrincipalRoundInput = {
 };
 
 export async function synthesizePrincipalSummary(input: PrincipalRoundInput): Promise<PrincipalSummary> {
-  return callLLMStructured(
-    input.providerConfig,
-    input.principal.mandate,
-    buildPrincipalPrompt(input.principal, input.transcript),
-    PrincipalSummarySchema
-  );
+  try {
+    return await callLLMStructured(
+      input.providerConfig,
+      input.principal.mandate,
+      buildPrincipalPrompt(input.principal, input.transcript),
+      PrincipalSummarySchema
+    );
+  } catch (error) {
+    if (!(error instanceof BudgetExceededError)) {
+      throw error;
+    }
+
+    const findings = input.transcript.rounds.flat();
+    return {
+      agreements: [],
+      disputes: [],
+      final_calls: findings.map((finding) => ({
+        finding,
+        decision: "Deferred for manual review because the configured model budget was exhausted.",
+        status: "deferred" as const,
+      })),
+      summary:
+        "## swarm-review\n\nThe configured model budget was exhausted before principal synthesis. " +
+        "Automated findings remain unsynthesized and require manual review.",
+    };
+  }
 }

--- a/src/agents/shared.ts
+++ b/src/agents/shared.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { callLLMStructured, normalizeFinding } from "../llm.js";
+import { BudgetExceededError } from "../budget.js";
 import { RawFindingSchema, type Finding, type RawFinding, type ProviderConfig, type AgentConfig } from "../types.js";
 
 const RawFindingArraySchema = z.array(RawFindingSchema);
@@ -31,12 +32,21 @@ export function resolveAgentProviderConfig(
 }
 
 export async function runAgentFindingRound(options: AgentRoundOptions): Promise<Finding[]> {
-  const rawFindings = await callLLMStructured<RawFinding[]>(
-    options.providerConfig,
-    options.system,
-    options.prompt,
-    RawFindingArraySchema
-  );
+  let rawFindings: RawFinding[];
+  try {
+    rawFindings = await callLLMStructured<RawFinding[]>(
+      options.providerConfig,
+      options.system,
+      options.prompt,
+      RawFindingArraySchema
+    );
+  } catch (error) {
+    if (error instanceof BudgetExceededError) {
+      console.log(`::warning::${error.message}`);
+      return [];
+    }
+    throw error;
+  }
 
   return rawFindings
     .map((finding, index) => normalizeFinding(finding, options.agentName, `${options.idPrefix}-${index + 1}`))

--- a/src/budget.ts
+++ b/src/budget.ts
@@ -17,6 +17,17 @@ type BudgetState = {
   skippedCalls: number;
 };
 
+export type BudgetReservation = {
+  providerConfig: ProviderConfig;
+  maxTokens: number;
+  reservedUsd: number;
+  model: string;
+  inputTokenUpperBound: number;
+};
+
+// Covers provider message framing and other request tokens not present in the raw prompts.
+const REQUEST_OVERHEAD_TOKEN_ALLOWANCE = 256;
+
 const budgetState: BudgetState = {
   committedUpperBoundUsd: 0,
   fallbackCalls: 0,
@@ -59,7 +70,10 @@ export function estimateCallUpperBoundUsd(
   }
 
   // Byte length is a conservative upper bound for BPE token counts.
-  const maxInputTokens = Buffer.byteLength(system, "utf8") + Buffer.byteLength(prompt, "utf8");
+  const maxInputTokens =
+    Buffer.byteLength(system, "utf8") +
+    Buffer.byteLength(prompt, "utf8") +
+    REQUEST_OVERHEAD_TOKEN_ALLOWANCE;
   return (maxInputTokens * rates.input + maxOutputTokens * rates.output) / 1_000_000;
 }
 
@@ -68,10 +82,20 @@ export function reserveBudgetedCall(
   system: string,
   prompt: string,
   requestedMaxTokens: number
-): { providerConfig: ProviderConfig; maxTokens: number; reservedUsd: number } {
+): BudgetReservation {
   const config = budgetState.config;
+  const inputTokenUpperBound =
+    Buffer.byteLength(system, "utf8") +
+    Buffer.byteLength(prompt, "utf8") +
+    REQUEST_OVERHEAD_TOKEN_ALLOWANCE;
   if (!config) {
-    return { providerConfig, maxTokens: requestedMaxTokens, reservedUsd: 0 };
+    return {
+      providerConfig,
+      maxTokens: requestedMaxTokens,
+      reservedUsd: 0,
+      model: providerConfig.config.model,
+      inputTokenUpperBound,
+    };
   }
 
   const maxTokens = Math.min(requestedMaxTokens, config.max_output_tokens);
@@ -83,11 +107,13 @@ export function reserveBudgetedCall(
       : []),
   ];
 
+  let hasKnownPricing = false;
   for (const candidate of candidates) {
     const reservedUsd = estimateCallUpperBoundUsd(candidate.model, system, prompt, maxTokens);
     if (reservedUsd === undefined) {
       continue;
     }
+    hasKnownPricing = true;
 
     if (budgetState.committedUpperBoundUsd + reservedUsd <= config.max_cost_usd) {
       budgetState.committedUpperBoundUsd += reservedUsd;
@@ -97,13 +123,53 @@ export function reserveBudgetedCall(
           `::notice::Budget guard selected fallback model ${candidate.model} for this call.`
         );
       }
-      return { providerConfig: candidate.config, maxTokens, reservedUsd };
+      return {
+        providerConfig: candidate.config,
+        maxTokens,
+        reservedUsd,
+        model: candidate.model,
+        inputTokenUpperBound,
+      };
     }
   }
 
   budgetState.skippedCalls += 1;
+  if (!hasKnownPricing) {
+    throw new BudgetExceededError(
+      `LLM call skipped: pricing is unknown for model ${primaryModel}` +
+        `${config.fallback_model ? ` and fallback ${config.fallback_model}` : ""}; ` +
+        "a strict cost cap cannot safely admit this call."
+    );
+  }
   throw new BudgetExceededError(
     `LLM call skipped: the configured $${config.max_cost_usd.toFixed(4)} budget cannot cover another call. ` +
       `Committed worst-case spend is $${budgetState.committedUpperBoundUsd.toFixed(4)}.`
+  );
+}
+
+export function settleSuccessfulBudgetedCall(
+  reservation: BudgetReservation,
+  responseText: string
+): void {
+  if (!budgetState.config || reservation.reservedUsd === 0) {
+    return;
+  }
+
+  const rates = getModelCostRates(reservation.model);
+  if (!rates) {
+    return;
+  }
+
+  // UTF-8 bytes conservatively bound BPE output tokens. Failed/ambiguous calls are
+  // deliberately not settled because the provider may still have charged for them.
+  const outputTokenUpperBound = Buffer.byteLength(responseText, "utf8");
+  const settledUpperBoundUsd =
+    (reservation.inputTokenUpperBound * rates.input + outputTokenUpperBound * rates.output) /
+    1_000_000;
+  budgetState.committedUpperBoundUsd = Math.max(
+    0,
+    budgetState.committedUpperBoundUsd -
+      reservation.reservedUsd +
+      Math.min(reservation.reservedUsd, settledUpperBoundUsd)
   );
 }

--- a/src/budget.ts
+++ b/src/budget.ts
@@ -1,0 +1,109 @@
+import { Buffer } from "node:buffer";
+
+import { getModelCostRates } from "./providers.js";
+import type { BudgetConfig, ProviderConfig } from "./types.js";
+
+export class BudgetExceededError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BudgetExceededError";
+  }
+}
+
+type BudgetState = {
+  config?: BudgetConfig;
+  committedUpperBoundUsd: number;
+  fallbackCalls: number;
+  skippedCalls: number;
+};
+
+const budgetState: BudgetState = {
+  committedUpperBoundUsd: 0,
+  fallbackCalls: 0,
+  skippedCalls: 0,
+};
+
+export function configureBudget(config: BudgetConfig | undefined): void {
+  budgetState.config = config;
+  budgetState.committedUpperBoundUsd = 0;
+  budgetState.fallbackCalls = 0;
+  budgetState.skippedCalls = 0;
+}
+
+export function getBudgetStatus(): Readonly<BudgetState> & { exhausted: boolean } {
+  return {
+    ...budgetState,
+    exhausted: budgetState.skippedCalls > 0,
+  };
+}
+
+function withModel(config: ProviderConfig, model: string): ProviderConfig {
+  return {
+    ...config,
+    config: {
+      ...config.config,
+      model,
+    },
+  } as ProviderConfig;
+}
+
+export function estimateCallUpperBoundUsd(
+  model: string,
+  system: string,
+  prompt: string,
+  maxOutputTokens: number
+): number | undefined {
+  const rates = getModelCostRates(model);
+  if (!rates) {
+    return undefined;
+  }
+
+  // Byte length is a conservative upper bound for BPE token counts.
+  const maxInputTokens = Buffer.byteLength(system, "utf8") + Buffer.byteLength(prompt, "utf8");
+  return (maxInputTokens * rates.input + maxOutputTokens * rates.output) / 1_000_000;
+}
+
+export function reserveBudgetedCall(
+  providerConfig: ProviderConfig,
+  system: string,
+  prompt: string,
+  requestedMaxTokens: number
+): { providerConfig: ProviderConfig; maxTokens: number; reservedUsd: number } {
+  const config = budgetState.config;
+  if (!config) {
+    return { providerConfig, maxTokens: requestedMaxTokens, reservedUsd: 0 };
+  }
+
+  const maxTokens = Math.min(requestedMaxTokens, config.max_output_tokens);
+  const primaryModel = providerConfig.config.model;
+  const candidates = [
+    { config: providerConfig, model: primaryModel, fallback: false },
+    ...(config.fallback_model && config.fallback_model !== primaryModel
+      ? [{ config: withModel(providerConfig, config.fallback_model), model: config.fallback_model, fallback: true }]
+      : []),
+  ];
+
+  for (const candidate of candidates) {
+    const reservedUsd = estimateCallUpperBoundUsd(candidate.model, system, prompt, maxTokens);
+    if (reservedUsd === undefined) {
+      continue;
+    }
+
+    if (budgetState.committedUpperBoundUsd + reservedUsd <= config.max_cost_usd) {
+      budgetState.committedUpperBoundUsd += reservedUsd;
+      if (candidate.fallback) {
+        budgetState.fallbackCalls += 1;
+        console.log(
+          `::notice::Budget guard selected fallback model ${candidate.model} for this call.`
+        );
+      }
+      return { providerConfig: candidate.config, maxTokens, reservedUsd };
+    }
+  }
+
+  budgetState.skippedCalls += 1;
+  throw new BudgetExceededError(
+    `LLM call skipped: the configured $${config.max_cost_usd.toFixed(4)} budget cannot cover another call. ` +
+      `Committed worst-case spend is $${budgetState.committedUpperBoundUsd.toFixed(4)}.`
+  );
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,5 +1,6 @@
 import type { Octokit } from "@octokit/rest";
 import { stripRereviewCommands } from "./events.js";
+import type { Finding } from "./types.js";
 
 const MANAGED_COMMENT_MARKER = "<!-- swarm-review:managed-comment -->";
 const MAX_FEEDBACK_COMMENTS = 20;
@@ -19,6 +20,26 @@ export function parsePositiveInteger(value: string): number | undefined {
 
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export function resolveReviewEvent(
+  requested: "COMMENT" | "APPROVE" | "REQUEST_CHANGES" | "AUTO",
+  acceptedFindings: Array<{ finding: Finding }>,
+  budgetExhausted: boolean
+): "COMMENT" | "APPROVE" | "REQUEST_CHANGES" {
+  if (budgetExhausted) {
+    return "COMMENT";
+  }
+  if (requested === "APPROVE" || requested === "REQUEST_CHANGES") {
+    return requested;
+  }
+  if (requested !== "AUTO") {
+    return "COMMENT";
+  }
+  if (acceptedFindings.some((item) => item.finding.severity === "blocking")) {
+    return "REQUEST_CHANGES";
+  }
+  return acceptedFindings.length === 0 ? "APPROVE" : "COMMENT";
 }
 
 function withManagedCommentMarker(body: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { loadSwarmConfig, readInput, resolveProviderConfig } from "./config.js";
 import { runDebateRounds } from "./agents/debate.js";
 import { runReviewRound } from "./agents/review.js";
 import { synthesizePrincipalSummary } from "./agents/principal.js";
-import { upsertPullRequestComment, updateCheckRun, parsePositiveInteger, createPullRequestReview, getDeveloperFeedback } from "./github.js";
+import { upsertPullRequestComment, updateCheckRun, parsePositiveInteger, createPullRequestReview, getDeveloperFeedback, resolveReviewEvent } from "./github.js";
 import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_API_ENDPOINT } from "./llm.js";
 import { renderDebateTranscriptMarkdown, formatInlineCommentBody } from "./format.js";
 import { runStaticAnalysis } from "./static_analysis.js";
@@ -14,6 +14,7 @@ import { DEFAULT_PROVIDER_CONFIG, type ProviderConfig, type SwarmConfig, type Fi
 import { tokenTracker, resetTokenTracker, calculateEstimatedCost } from "./providers.js";
 import { buildCodebaseIndex } from "./context.js";
 import { isTrustedRereviewActor, parseRereviewCommand } from "./events.js";
+import { configureBudget, getBudgetStatus } from "./budget.js";
 
 type IssueCommentEventPayload = {
   issue?: { pull_request?: unknown };
@@ -95,6 +96,13 @@ function buildStatsBlock(): string {
   const costStr = hasUnknown
     ? `$${cost.toFixed(4)}+ USD (contains unknown model pricing)`
     : `$${cost.toFixed(4)} USD`;
+  const budget = getBudgetStatus();
+  const budgetLines = budget.config
+    ? [
+        `> - **Budget upper bound committed**: $${budget.committedUpperBoundUsd.toFixed(4)} / $${budget.config.max_cost_usd.toFixed(4)} USD`,
+        `> - **Fallback / skipped calls**: ${budget.fallbackCalls} / ${budget.skippedCalls}`,
+      ]
+    : [];
 
   return [
     `> [!NOTE]`,
@@ -102,6 +110,7 @@ function buildStatsBlock(): string {
     `> - **Total LLM Calls**: ${tokenTracker.totalCalls}`,
     `> - **Total Tokens**: ${totalInput.toLocaleString()} input / ${totalOutput.toLocaleString()} output`,
     `> - **Estimated Cost**: ${costStr}`,
+    ...budgetLines,
     `> - **Usage Breakdown**:`,
     ...breakdown,
   ].join("\n");
@@ -171,6 +180,7 @@ async function main(): Promise<void> {
   console.log(`Using provider: ${providerConfig.type}`);
 
   resetTokenTracker();
+  configureBudget(swarmConfig.budget);
 
   const diff = await fetchPullRequestDiff(octokit, owner, repo, pullNumber);
   const linterFindings = await runStaticAnalysis(swarmConfig.static_analysis, workspaceRoot);
@@ -256,21 +266,11 @@ async function main(): Promise<void> {
     }
   }
 
-  let actualEvent: "COMMENT" | "APPROVE" | "REQUEST_CHANGES" = "COMMENT";
-  if (reviewEvent === "APPROVE") {
-    actualEvent = "APPROVE";
-  } else if (reviewEvent === "REQUEST_CHANGES") {
-    actualEvent = "REQUEST_CHANGES";
-  } else if (reviewEvent === "AUTO") {
-    const hasBlocking = acceptedFindings.some((item) => item.finding.severity === "blocking");
-    if (hasBlocking) {
-      actualEvent = "REQUEST_CHANGES";
-    } else if (acceptedFindings.length === 0) {
-      actualEvent = "APPROVE";
-    } else {
-      actualEvent = "COMMENT";
-    }
-  }
+  const actualEvent = resolveReviewEvent(
+    reviewEvent,
+    acceptedFindings,
+    getBudgetStatus().exhausted
+  );
 
   if (isInline || reviewEvent !== "COMMENT") {
     const validLinesMap = new Map<string, Set<number>>();

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { FindingSchema, RawFindingSchema, type Finding, type RawFinding, type ProviderConfig } from "./types.js";
 import { createProvider, type LLMProvider } from "./providers.js";
+import { reserveBudgetedCall } from "./budget.js";
 
 const ANTHROPIC_MESSAGES_ENDPOINT = "https://api.anthropic.com/v1/messages";
 
@@ -54,8 +55,9 @@ export async function callLLM(
   prompt: string,
   maxTokens = 4096
 ): Promise<string> {
-  const provider = createProvider(providerConfig);
-  return provider.call(system, prompt, maxTokens);
+  const reservation = reserveBudgetedCall(providerConfig, system, prompt, maxTokens);
+  const provider = createProvider(reservation.providerConfig);
+  return provider.call(system, prompt, reservation.maxTokens);
 }
 
 export async function callLLMStructured<T>(
@@ -68,9 +70,11 @@ export async function callLLMStructured<T>(
   let lastResponseText = "";
 
   for (let attempt = 1; attempt <= 3; attempt += 1) {
+    // Provider/network errors are not schema errors and must not trigger another paid call.
+    const rawText = await callLLM(providerConfig, system, currentPrompt);
+    lastResponseText = rawText;
+
     try {
-      const rawText = await callLLM(providerConfig, system, currentPrompt);
-      lastResponseText = rawText;
       const jsonText = extractJsonText(rawText);
       const parsed = JSON.parse(jsonText) as unknown;
       return schema.parse(parsed);

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import { FindingSchema, RawFindingSchema, type Finding, type RawFinding, type ProviderConfig } from "./types.js";
 import { createProvider, type LLMProvider } from "./providers.js";
-import { reserveBudgetedCall } from "./budget.js";
+import { reserveBudgetedCall, settleSuccessfulBudgetedCall } from "./budget.js";
 
 const ANTHROPIC_MESSAGES_ENDPOINT = "https://api.anthropic.com/v1/messages";
 
@@ -57,7 +57,9 @@ export async function callLLM(
 ): Promise<string> {
   const reservation = reserveBudgetedCall(providerConfig, system, prompt, maxTokens);
   const provider = createProvider(reservation.providerConfig);
-  return provider.call(system, prompt, reservation.maxTokens);
+  const responseText = await provider.call(system, prompt, reservation.maxTokens);
+  settleSuccessfulBudgetedCall(reservation, responseText);
+  return responseText;
 }
 
 export async function callLLMStructured<T>(

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -63,7 +63,7 @@ export function resetTokenTracker() {
   tokenTracker.totalCalls = 0;
 }
 
-const MODEL_COSTS: Record<string, { input: number; output: number }> = {
+export const MODEL_COSTS: Record<string, { input: number; output: number }> = {
   "claude-3-5-sonnet-latest": { input: 3.0, output: 15.0 },
   "claude-3-5-sonnet-20241022": { input: 3.0, output: 15.0 },
   "claude-3-5-sonnet-20240620": { input: 3.0, output: 15.0 },
@@ -86,17 +86,24 @@ const MODEL_COSTS: Record<string, { input: number; output: number }> = {
   "gemini-1.5-flash": { input: 0.075, output: 0.30 },
 };
 
+export function getModelCostRates(model: string): { input: number; output: number } | undefined {
+  const normalizedModel = model.toLowerCase();
+  const baseModel = normalizedModel.split("/").at(-1) ?? normalizedModel;
+  const matchedKey = Object.keys(MODEL_COSTS).find(
+    (key) => key.toLowerCase() === normalizedModel || key.toLowerCase() === baseModel
+  );
+
+  return matchedKey ? MODEL_COSTS[matchedKey] : undefined;
+}
+
 export function calculateEstimatedCost(): { cost: number; hasUnknown: boolean } {
   let totalCost = 0;
   let hasUnknown = false;
 
   for (const [model, usage] of Object.entries(tokenTracker.models)) {
-    const matchedKey = Object.keys(MODEL_COSTS).find(
-      (k) => model.toLowerCase().includes(k.toLowerCase()) || k.toLowerCase().includes(model.toLowerCase())
-    );
-    
-    if (matchedKey) {
-      const rates = MODEL_COSTS[matchedKey];
+    const rates = getModelCostRates(model);
+
+    if (rates) {
       const modelCost = (usage.inputTokens * rates.input + usage.outputTokens * rates.output) / 1_000_000;
       totalCost += modelCost;
     } else {

--- a/src/tests/budget.test.ts
+++ b/src/tests/budget.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  BudgetExceededError,
+  configureBudget,
+  getBudgetStatus,
+  reserveBudgetedCall,
+} from "../budget.js";
+import type { ProviderConfig } from "../types.js";
+import { runAgentFindingRound } from "../agents/shared.js";
+import { synthesizePrincipalSummary } from "../agents/principal.js";
+
+const primary: ProviderConfig = {
+  type: "openai",
+  config: { apiKey: "test", model: "gpt-4o" },
+};
+
+test("budget guard reserves a conservative upper bound and clamps output tokens", (t) => {
+  t.after(() => configureBudget(undefined));
+  configureBudget({ max_cost_usd: 1, max_output_tokens: 1_000 });
+
+  const reservation = reserveBudgetedCall(primary, "system", "prompt", 4_096);
+
+  assert.equal(reservation.providerConfig.config.model, "gpt-4o");
+  assert.equal(reservation.maxTokens, 1_000);
+  assert.ok(reservation.reservedUsd > 0);
+  assert.equal(getBudgetStatus().committedUpperBoundUsd, reservation.reservedUsd);
+});
+
+test("budget guard switches to a configured cheaper fallback", (t) => {
+  t.after(() => configureBudget(undefined));
+  configureBudget({
+    max_cost_usd: 0.01,
+    fallback_model: "gpt-4o-mini",
+    max_output_tokens: 4_096,
+  });
+
+  const reservation = reserveBudgetedCall(primary, "system", "prompt", 4_096);
+
+  assert.equal(reservation.providerConfig.config.model, "gpt-4o-mini");
+  assert.equal(getBudgetStatus().fallbackCalls, 1);
+});
+
+test("budget guard refuses calls that would exceed the shared run cap", (t) => {
+  t.after(() => configureBudget(undefined));
+  configureBudget({ max_cost_usd: 0.001, max_output_tokens: 1_000 });
+
+  assert.throws(
+    () => reserveBudgetedCall(primary, "system", "prompt", 4_096),
+    BudgetExceededError
+  );
+  assert.equal(getBudgetStatus().skippedCalls, 1);
+  assert.equal(getBudgetStatus().exhausted, true);
+});
+
+test("budget guard rejects unknown pricing unless a known fallback fits", (t) => {
+  t.after(() => configureBudget(undefined));
+  configureBudget({ max_cost_usd: 1, max_output_tokens: 1_000 });
+  const unknown: ProviderConfig = {
+    type: "custom",
+    config: { apiKey: "test", model: "private-model", baseURL: "https://example.com/v1" },
+  };
+
+  assert.throws(
+    () => reserveBudgetedCall(unknown, "system", "prompt", 1_000),
+    /configured.*budget cannot cover another call/i
+  );
+});
+
+test("reviewer calls degrade to an empty result without issuing an unaffordable request", async (t) => {
+  t.after(() => configureBudget(undefined));
+  configureBudget({ max_cost_usd: 0.000001, max_output_tokens: 1_000 });
+  const originalFetch = globalThis.fetch;
+  let fetchCalled = false;
+  globalThis.fetch = (async () => {
+    fetchCalled = true;
+    throw new Error("fetch should not be called");
+  }) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const findings = await runAgentFindingRound({
+    providerConfig: primary,
+    system: "system",
+    prompt: "prompt",
+    agentName: "security",
+    idPrefix: "review-security",
+    minConfidence: 0.5,
+  });
+
+  assert.deepEqual(findings, []);
+  assert.equal(fetchCalled, false);
+});
+
+test("principal synthesis defers findings when its call cannot fit", async (t) => {
+  t.after(() => configureBudget(undefined));
+  configureBudget({ max_cost_usd: 0.000001, max_output_tokens: 1_000 });
+  const finding = {
+    id: "review-security-1",
+    agent: "security",
+    severity: "blocking" as const,
+    file: "src/app.ts",
+    line: 10,
+    claim: "Unsafe behavior.",
+    confidence: 0.9,
+  };
+
+  const summary = await synthesizePrincipalSummary({
+    principal: { mandate: "Synthesize." },
+    transcript: { rounds: [[finding]], agents: [{ name: "security", mandate: "Review." }] },
+    providerConfig: primary,
+  });
+
+  assert.equal(summary.final_calls[0]?.status, "deferred");
+  assert.match(summary.summary, /budget was exhausted/i);
+});

--- a/src/tests/budget.test.ts
+++ b/src/tests/budget.test.ts
@@ -6,6 +6,7 @@ import {
   configureBudget,
   getBudgetStatus,
   reserveBudgetedCall,
+  settleSuccessfulBudgetedCall,
 } from "../budget.js";
 import type { ProviderConfig } from "../types.js";
 import { runAgentFindingRound } from "../agents/shared.js";
@@ -42,6 +43,27 @@ test("budget guard switches to a configured cheaper fallback", (t) => {
   assert.equal(getBudgetStatus().fallbackCalls, 1);
 });
 
+test("successful calls release unused output reservation conservatively", (t) => {
+  t.after(() => configureBudget(undefined));
+  configureBudget({ max_cost_usd: 1, max_output_tokens: 1_000 });
+
+  const reservation = reserveBudgetedCall(primary, "system", "prompt", 1_000);
+  const before = getBudgetStatus().committedUpperBoundUsd;
+  settleSuccessfulBudgetedCall(reservation, "short response");
+
+  assert.ok(getBudgetStatus().committedUpperBoundUsd < before);
+  assert.ok(getBudgetStatus().committedUpperBoundUsd > 0);
+});
+
+test("unsettled failed calls retain their worst-case reservation", (t) => {
+  t.after(() => configureBudget(undefined));
+  configureBudget({ max_cost_usd: 1, max_output_tokens: 1_000 });
+
+  const reservation = reserveBudgetedCall(primary, "system", "prompt", 1_000);
+
+  assert.equal(getBudgetStatus().committedUpperBoundUsd, reservation.reservedUsd);
+});
+
 test("budget guard refuses calls that would exceed the shared run cap", (t) => {
   t.after(() => configureBudget(undefined));
   configureBudget({ max_cost_usd: 0.001, max_output_tokens: 1_000 });
@@ -64,7 +86,7 @@ test("budget guard rejects unknown pricing unless a known fallback fits", (t) =>
 
   assert.throws(
     () => reserveBudgetedCall(unknown, "system", "prompt", 1_000),
-    /configured.*budget cannot cover another call/i
+    /pricing is unknown.*strict cost cap/i
   );
 });
 

--- a/src/tests/config.test.ts
+++ b/src/tests/config.test.ts
@@ -27,6 +27,10 @@ test("loadSwarmConfig reads a local config file", async () => {
       "debate:",
       "  rounds: 1",
       "  min_confidence: 0.7",
+      "budget:",
+      "  max_cost_usd: 1.5",
+      "  fallback_model: gpt-4o-mini",
+      "  max_output_tokens: 2048",
       "principal:",
       "  mandate: Make the final call.",
       "output:",
@@ -42,6 +46,9 @@ test("loadSwarmConfig reads a local config file", async () => {
   assert.equal(config.agents[0]?.min_confidence, 0.85);
   assert.equal(config.debate.rounds, 1);
   assert.equal(config.debate.min_confidence, 0.7);
+  assert.equal(config.budget?.max_cost_usd, 1.5);
+  assert.equal(config.budget?.fallback_model, "gpt-4o-mini");
+  assert.equal(config.budget?.max_output_tokens, 2048);
   assert.equal(config.principal.mandate, "Make the final call.");
   assert.equal(config.output.mode, "full");
 });

--- a/src/tests/github.test.ts
+++ b/src/tests/github.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { parsePositiveInteger, upsertPullRequestComment, updateCheckRun, getDeveloperFeedback } from "../github.js";
+import { parsePositiveInteger, resolveReviewEvent, upsertPullRequestComment, updateCheckRun, getDeveloperFeedback } from "../github.js";
 
 type MockComment = {
   id: number;
@@ -212,4 +212,24 @@ test("getDeveloperFeedback bounds comment count and total prompt size", async ()
   assert.ok(feedback.length <= 20);
   assert.ok(feedback.reduce((total, entry) => total + entry.length, 0) <= 20_000);
   assert.match(feedback[0] ?? "", /^\[user-5\]:/);
+});
+
+test("resolveReviewEvent never approves after budget exhaustion", () => {
+  assert.equal(resolveReviewEvent("APPROVE", [], true), "COMMENT");
+  assert.equal(resolveReviewEvent("AUTO", [], true), "COMMENT");
+});
+
+test("resolveReviewEvent derives automatic review decisions", () => {
+  const finding = {
+    id: "finding-1",
+    agent: "security",
+    severity: "blocking" as const,
+    file: "src/app.ts",
+    line: 1,
+    claim: "Unsafe behavior.",
+    confidence: 0.9,
+  };
+
+  assert.equal(resolveReviewEvent("AUTO", [], false), "APPROVE");
+  assert.equal(resolveReviewEvent("AUTO", [{ finding }], false), "REQUEST_CHANGES");
 });

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -3,6 +3,7 @@ import "./agents.debate.test.js";
 import "./agents.principal.test.js";
 import "./agents.review.test.js";
 import "./agents.shared.test.js";
+import "./budget.test.js";
 import "./diff.test.js";
 import "./events.test.js";
 import "./format.test.js";

--- a/src/tests/llm.test.ts
+++ b/src/tests/llm.test.ts
@@ -115,3 +115,29 @@ test("callLLMStructured self-heals after validation failure", async (t) => {
   assert.ok(promptsSent[1].includes("CRITICAL: Your previous response failed validation and could not be parsed."));
   assert.ok(promptsSent[1].includes("wrongField"));
 });
+
+test("callLLMStructured does not repeat paid calls for provider errors", async (t) => {
+  const { callLLMStructured } = await import("../llm.js");
+  const { z } = await import("zod");
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+  globalThis.fetch = (async () => {
+    attempts += 1;
+    return new Response("bad request", { status: 400 });
+  }) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  await assert.rejects(
+    () =>
+      callLLMStructured(
+        { type: "anthropic", config: { apiKey: "test-key", model: "claude-3-5-sonnet-latest" } },
+        "system",
+        "prompt",
+        z.array(z.unknown())
+      ),
+    /Anthropic request failed with 400/
+  );
+  assert.equal(attempts, 1);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -221,6 +221,12 @@ export const ContextEnrichmentConfigSchema = z.object({
   ignored_dirs: z.array(z.string()).optional(),
 });
 
+export const BudgetConfigSchema = z.object({
+  max_cost_usd: z.number().positive(),
+  fallback_model: z.string().min(1).optional(),
+  max_output_tokens: z.number().int().positive().max(32_768).default(4_096),
+});
+
 export const SwarmConfigSchema = z.object({
   agents: z.array(AgentConfigSchema).min(1).default(DEFAULT_AGENTS),
   debate: DebateConfigSchema.default(DEFAULT_DEBATE_CONFIG),
@@ -240,6 +246,7 @@ export const SwarmConfigSchema = z.object({
     include_patterns: [],
   }),
   provider: ProviderConfigSchema.optional(),
+  budget: BudgetConfigSchema.optional(),
   static_analysis: StaticAnalysisConfigSchema.default({
     enabled: false,
     commands: [],
@@ -257,6 +264,7 @@ export type SwarmConfig = z.infer<typeof SwarmConfigSchema>;
 export type StaticAnalysisCommand = z.infer<typeof StaticAnalysisCommandSchema>;
 export type StaticAnalysisConfig = z.infer<typeof StaticAnalysisConfigSchema>;
 export type ContextEnrichmentConfig = z.infer<typeof ContextEnrichmentConfigSchema>;
+export type BudgetConfig = z.infer<typeof BudgetConfigSchema>;
 
 
 export const FileDiffSchema = z.object({


### PR DESCRIPTION
## What changed
- add optional strict per-run `budget` configuration
- reserve a conservative worst-case cost before each call so parallel agents cannot oversubscribe the cap
- switch to a configured same-provider fallback model when the primary no longer fits
- clamp requested output tokens to the configured budget limit
- skip unaffordable reviewer calls and emit a manual-review principal summary if synthesis cannot fit
- force neutral review status after budget exhaustion, including when `APPROVE` was requested
- stop treating provider/API failures as schema failures that warrant extra paid calls
- expose budget reservations, fallback calls, and skipped calls in run statistics

## Why
The action previously reported cost only after spending it. High-volume repositories need a real upper bound that remains safe under parallel review calls and malformed-output retries.

## Validation
- `npm test` (55 passing)
- `npm run typecheck`
- `git diff --check`

## Design note
Reservations use UTF-8 input byte length plus the output-token cap as a conservative token upper bound. This may stop early, but it will not knowingly exceed the configured cap. Budgeted models require a known price; a known fallback can cover custom or unpriced primary models.