### PR TITLE
Prepare the v1.0.0 release candidate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  validate-and-update-major-tag:
+    if: github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Validate release version
+        id: version
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must be an exact stable semver such as v1.0.0." >&2
+            exit 1
+          fi
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          if [[ "$RELEASE_TAG" != "v$PACKAGE_VERSION" ]]; then
+            echo "Release tag $RELEASE_TAG does not match package version $PACKAGE_VERSION." >&2
+            exit 1
+          fi
+          MAJOR_TAG="${RELEASE_TAG%%.*}"
+          LATEST_TAG="$(git tag --list "$MAJOR_TAG.*" --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)"
+          if [[ "$RELEASE_TAG" != "$LATEST_TAG" ]]; then
+            echo "Refusing to move $MAJOR_TAG backward from latest tag $LATEST_TAG to $RELEASE_TAG." >&2
+            exit 1
+          fi
+          echo "major_tag=$MAJOR_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Verify committed action bundle
+        run: |
+          npm run bundle
+          git diff --exit-code -- dist/
+
+      - name: Advance floating major tag
+        env:
+          MAJOR_TAG: ${{ steps.version.outputs.major_tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag --force "$MAJOR_TAG" HEAD
+          git push origin "refs/tags/$MAJOR_TAG" --force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## v1.0.0 - 2026-07-14
+
 ### Added
+- A committed, standalone GitHub Action bundle with CI enforcement against stale generated output.
 - Per-agent `system_prompt` instructions for specialized reviewer personalities while preserving built-in output guardrails.
 - Per-agent `min_confidence` thresholds, falling back to the global debate threshold when omitted.
 - Trusted conversational re-reviews triggered by exact `/swarm-review` commands on pull requests.
@@ -21,6 +24,7 @@ All notable changes to this project are documented in this file.
 - Normalized Anthropic and OpenAI-compatible base URLs to their request endpoints while preserving full endpoint URLs.
 - Resolved documented `$ENV_VAR` provider API-key references instead of sending them as literal credentials.
 - Corrected legacy provider documentation and action author metadata.
+- Corrected diff prompt budget accounting for metadata, exclusions, and separators.
 
 ## v0.7.0 - 2026-05-21
 

--- a/README.md
+++ b/README.md
@@ -510,12 +510,13 @@ Tune these values based on repository size and expected review depth.
 
 ## Release Process
 
-Releases are delivered in stage-specific pull requests so each risk domain is reviewed independently. This keeps reviews focused and makes rollback decisions straightforward. For example, a release cycle typically includes:
+Releases are delivered in focused pull requests so each risk domain can be reviewed and rolled back independently. To publish a stable release:
 
-1. Stability and safety hardening.
-2. Diff scaling and runtime reliability.
-3. Coverage expansion for key helpers.
-4. Documentation and release metadata.
+1. Merge the release metadata PR after CI passes and create the matching `vX.Y.Z` tag and GitHub release.
+2. The release workflow checks that the tag matches `package.json`, runs the full tests, and verifies the committed bundle.
+3. For stable releases, the workflow advances the floating major tag (for example, `v1`) to the verified release commit.
+
+Consumers should pin `EvanGribar/Swarm-Review@v1` for compatible v1 updates or a full tag such as `@v1.0.0` for an immutable version.
 
 
 ## Project Layout

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,90 +1,38 @@
 # Swarm-Review Roadmap
 
-Welcome to the future of **swarm-review**! This roadmap outlines our upcoming development milestones, technical design goals, and feature releases as we progress toward a robust, enterprise-grade `v1.0.0` release.
+This roadmap contains only work planned after the v1.0.0 production release.
 
 ```mermaid
 gantt
-    title Swarm-Review Release Timeline
-    dateFormat  YYYY-MM-DD
+    title Swarm-Review Future Releases
+    dateFormat YYYY-MM-DD
     section Future Milestones
-    v1.0.0 (Production Hardening & Cost Controls) :active, 2026-07-21, 20d
-    v1.1.0 (Integration Framework & Web UI Dashboard) : 2026-08-10, 20d
-    v1.2.0 (IDE Extensions & Advanced Context) : 2026-08-30, 20d
+    v1.1.0 (Scale and Observability) :active, 2026-08-10, 20d
+    v1.2.0 (Local Tools and Dashboard) : 2026-08-30, 20d
+    v1.3.0 (IDE and Policy Integrations) : 2026-09-20, 20d
 ```
 
----
+## Vision
 
-## 🗺️ Vision & North Star
-Our goal is to make **swarm-review** the premier open-source multi-agent PR review tool. It should:
-1. **Be Zero-Config by Default**: Work out-of-the-box with a sensible default agent roster.
-2. **Read Like a Live Review Session**: Replicate the collaborative nature of human PR reviews.
-3. **Be Cost-Conscious**: Support budgeting, caching, and token usage optimization to run cheaply at scale.
+Swarm-review should remain zero-hosting by default, read like a real engineering review, and make model cost and behavior observable and controllable.
 
----
+## v1.1.0: Scale and Observability
 
-## 🚀 Milestones
+- Cache review inputs and results for unchanged files without weakening commit-specific correctness.
+- Export optional OpenTelemetry traces for provider latency, retries, token usage, and debate stages.
+- Add model pricing configuration so private and newly released models can participate in strict budgets.
+- Expand integration coverage for large diffs, provider gateways, and rate-limit behavior.
 
----
+## v1.2.0: Local Tools and Dashboard
 
-### 📍 Phase 4: Production Hardening, Cost Controls, & Caching (v1.0.0)
-*Preparing swarm-review for enterprise adoption, high-volume repositories, and strict security requirements.*
+- Add a local CLI for reviewing working-tree changes and branch diffs.
+- Provide an optional dashboard for exploring findings, rebuttals, and principal decisions.
+- Support reusable, versioned agent-roster packages.
 
-#### Proposed Features
-- **Self-Correction & Schema Retry**:
-  - If a model's output fails Zod validation, supply the schema error back to the model for a single-pass repair/retry.
-- **Token Budgeting & Auto-Fallback**:
-  - Define a strict monetary budget per PR or run.
-  - If the budget is close to exhaustion, automatically switch agents to cheaper models (e.g., `gpt-4o-mini`, `gemini-2.0-flash`) or skip the debate rounds.
-- **Caching Mechanism**:
-  - Store previous reviews of files/commits in GitHub Actions Cache.
-  - Skip review/debate cycles for files that have not changed relative to a cached commit.
-- **OpenTelemetry & LangSmith Integrations**:
-  - Support export of tracing data to help developers debug prompt latency, agent reasoning, and token usage metrics.
+## v1.3.0: IDE and Policy Integrations
 
----
+- Add editor integrations for pre-push review loops.
+- Integrate language-server and code-graph context providers.
+- Support branch-specific policy rules and agent assignments.
 
-## 🛠️ Configuration Changes (Proposed Schema)
-```yaml
-# Additions to .swarm.yml in v1.0.0
-budget:
-  max_cost_usd: 1.50
-  fallback_model: gpt-4o-mini
-  
-cache:
-  enabled: true
-  key: swarm-review-${{ github.sha }}
-
-static_analysis:
-  enabled: true
-  commands:
-    - run: npm run lint
-```
-
-### 📍 Phase 5: Integration Framework & Web UI Dashboard (v1.1.0)
-*Expanding beyond GitHub Actions to support local development environments, pre-commit hooks, and a visual dashboard for review reports.*
-
-#### Proposed Features
-- **Local CLI Review**:
-  - Run the swarm locally on unstaged changes or git branches, producing markdown or HTML reports.
-- **Web UI Dashboard**:
-  - A lightweight local web app to view complex debates interactively, trace decision paths, and inspect code signatures side-by-side.
-- **Pluggable Agent Packages**:
-  - Support importing third-party agent rosters and custom prompts from npm packages or external URLs.
-
----
-
-### 📍 Phase 6: IDE Extensions & Advanced Context (v1.2.0)
-*Integrating review cycles directly into developers' inner-loop development workspaces.*
-
-#### Proposed Features
-- **VS Code & Cursor Extensions**:
-  - Run the review swarm locally on modified files directly inside the editor before committing/pushing.
-- **Language Server (LSP) Code Graph Context**:
-  - Parse deep dependency relationships across the entire codebase to understand the impact of PR changes globally.
-- **Branch-Specific Policy Rules**:
-  - Define customized rules and agent assignments depending on the target branch (e.g., stricter security checks on `release` or `main`).
-
----
-
-> [!IMPORTANT]
-> This roadmap is a living document. We welcome community input and feature requests. Please raise issues on GitHub to discuss changes or suggest improvements to the proposed phases!
+This roadmap is a living document. Please use GitHub issues to propose or discuss future milestones.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+| --- | --- |
+| 1.x | Yes |
+| Earlier releases | No |
+
+## Reporting a vulnerability
+
+Please do not open a public issue for a suspected vulnerability. Use [GitHub private vulnerability reporting](https://github.com/EvanGribar/Swarm-Review/security/advisories/new) and include:
+
+- the affected version or commit;
+- reproduction steps or a proof of concept;
+- the expected security impact; and
+- any suggested mitigation.
+
+You should receive an acknowledgment within seven days. Confirmed issues will be coordinated privately until a fix and advisory are ready.

--- a/action.yml
+++ b/action.yml
@@ -6,14 +6,14 @@ inputs:
     description: GitHub token with permission to comment on pull requests.
     required: true
   anthropic-api-key:
-    description: Legacy: API key for Anthropic. For multi-provider support, configure provider in .swarm.yml instead.
+    description: "Legacy: API key for Anthropic. For multi-provider support, configure provider in .swarm.yml instead."
     required: false
   anthropic-model:
-    description: Legacy: Model name for Anthropic. For multi-provider support, configure provider in .swarm.yml instead.
+    description: "Legacy: Model name for Anthropic. For multi-provider support, configure provider in .swarm.yml instead."
     required: false
     default: claude-3-5-sonnet-latest
   api-endpoint:
-    description: Custom API endpoint for Anthropic-compatible providers (e.g., OpenRouter, local LLM).
+    description: Optional API base URL or full messages endpoint for an Anthropic-compatible service.
     required: false
   config-path:
     description: Path to the swarm configuration file. Use this to configure providers, agents, and debate settings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swarm-review",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "swarm-review",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^21.0.2",
@@ -18,6 +18,9 @@
         "@types/node": "^22.13.10",
         "@vercel/ncc": "^0.38.4",
         "typescript": "^5.8.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@octokit/auth-token": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "swarm-review",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": ">=20"
+  },
   "description": "GitHub Action that runs a multi-agent pull request review swarm with structured debate and principal synthesis.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -9,6 +9,7 @@ import "./events.test.js";
 import "./format.test.js";
 import "./github.test.js";
 import "./llm.test.js";
+import "./metadata.test.js";
 import "./prompts.test.js";
 import "./providers.test.js";
 import "./static_analysis.test.js";

--- a/src/tests/metadata.test.ts
+++ b/src/tests/metadata.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import yaml from "js-yaml";
+
+type ActionMetadata = {
+  inputs?: Record<string, unknown>;
+  runs?: { using?: string; main?: string };
+};
+
+type ReleaseWorkflow = {
+  on?: { release?: { types?: string[] } };
+  jobs?: Record<string, unknown>;
+};
+
+test("release and action metadata are valid and aligned with v1", async () => {
+  const [actionText, releaseText, packageText, lockText] = await Promise.all([
+    readFile("action.yml", "utf8"),
+    readFile(".github/workflows/release.yml", "utf8"),
+    readFile("package.json", "utf8"),
+    readFile("package-lock.json", "utf8"),
+  ]);
+
+  const action = yaml.load(actionText) as ActionMetadata;
+  const release = yaml.load(releaseText) as ReleaseWorkflow;
+  const packageJson = JSON.parse(packageText) as { version?: string };
+  const packageLock = JSON.parse(lockText) as {
+    version?: string;
+    packages?: Record<string, { version?: string }>;
+  };
+
+  assert.equal(action.runs?.using, "node20");
+  assert.equal(action.runs?.main, "dist/index.js");
+  assert.ok(action.inputs?.["pull-number"]);
+  assert.deepEqual(release.on?.release?.types, ["published"]);
+  assert.ok(release.jobs?.["validate-and-update-major-tag"]);
+  assert.equal(packageJson.version, "1.0.0");
+  assert.equal(packageLock.version, packageJson.version);
+  assert.equal(packageLock.packages?.[""]?.version, packageJson.version);
+});


### PR DESCRIPTION
## Release candidate

This is the final metadata and publication gate for v1.0.0. It follows merged PRs #58-#63.

## Summary
- bump package and lockfile metadata to `1.0.0` and require Node.js 20+
- close the v1 changelog milestone and move incomplete caching/observability work into the post-v1 roadmap
- add a private vulnerability-reporting policy
- add a stable-release workflow that validates exact semver/package alignment, reruns tests, verifies the committed bundle, prevents major-tag regression, and advances the floating `v1` tag
- make `action.yml` strict-YAML compatible and add a permanent metadata contract test

## Verification
- clean `npm ci` (0 vulnerabilities)
- `npm test -- --runInBand` (75 passing)
- `npm run bundle` with filtered artifact hash matching the committed bundle
- strict YAML parse for action metadata and all workflows
- package and lockfile versions aligned at `1.0.0`
- `git diff --check`

## Publication after merge
Create and publish the `v1.0.0` GitHub release from the merge commit. The release workflow will validate it and create/update the floating `v1` tag.