### PR TITLE
chore(security): resolve code-scanning alerts, add CodeQL SAST

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,35 @@
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly SAST sweep so Scorecard's SAST check sees coverage on every commit window.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@6f5948dfacef28e207b48d0905cf90c03365536d # v3
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@6f5948dfacef28e207b48d0905cf90c03365536d # v3
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,11 +25,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@6f5948dfacef28e207b48d0905cf90c03365536d # v3
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           languages: javascript-typescript
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@6f5948dfacef28e207b48d0905cf90c03365536d # v3
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -9,7 +9,9 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  checks: write
+  # Add `checks: write` here only if you pass `check-run-id` to the action.
+  # It is intentionally omitted so the default workflow follows least privilege
+  # (see Scorecard Token-Permissions).
 
 jobs:
   review:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           target-branch: main
           config-file: release-please-config.json

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  checks: write
+  # checks: write  # only needed if you pass `check-run-id` to the action
 
 jobs:
   review:


### PR DESCRIPTION
## What does this PR change?

Addresses the open code-scanning (Scorecard) alerts with code fixes:

- \example.yml\ + README quickstart: drop unused \checks: write\ (least privilege; fixes Token-Permissions #113). The action only needs it when \check-run-id\ is passed — now documented inline.
- \elease-please.yml\: pin \googleapis/release-please-action\ to its v4 SHA (fixes Pinned-Dependencies #117).
- New \codeql-analysis.yml\: CodeQL SAST for \javascript-typescript\ on push, PR, and weekly schedule, with fully SHA-pinned actions (addresses SAST #110 once the first scan completes).

Companion repo-settings change (applied directly, reversible): added \uild-and-test\ as a required status check in the Main Branch Protection ruleset, closing the 'no status checks' gap in Branch-Protection #18. No review-count or merge-method changes — solo merge flow is unaffected.

## Verification

- [ ] CI (build-and-test, self-review, specbridge validation) green
- [ ] New CodeQL run completes on this PR
- [ ] Scorecard rescan clears #113 / #117 automatically; #110 clears after CodeQL results land

## Deliberately not changed (proposing dismissal with justification)

- Token-Permissions #114 (release.yml job) and #115 (release-please top level): \contents: write\ is functionally required (tag push, release PRs). Scoping it elsewhere just moves the flag.
- Branch-Protection #18 residue (2-reviewer count, last-push approval), Code-Review #44 (0/22 approved changesets): unreachable for a single-maintainer project.
- Fuzzing #47, CII-Best-Practices #46: not applicable (no fuzz harness; GHA-only project).