### PR TITLE
docs: audit consistency fixes across README, AGENTS, ROADMAP, SPECBRIDGE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,11 +31,11 @@ If **Context Enrichment** is enabled, import dependencies in changed files are r
 
 If **SpecBridge Requirement Evaluation** is enabled, checked-in `.specbridge/requirements.json` contracts are evaluated against the PR patch, generating structured `coverage.json` and `findings.sarif` artifacts.
 
-### Stage 2 — evidence-aware principal synthesis (default)
-A principal engineer agent receives all independent reviewer findings (along with optional static analysis and requirement evaluation results) and synthesizes the final PR review summary. The principal eliminates false positives, resolves overlaps, and makes final calls.
-
-### Stage 3 — optional structured debate (opt-in)
+### Stage 2 — optional structured debate (opt-in)
 When debate is explicitly enabled (`debate.enabled: true` or `debate.rounds > 0`), agents engage in structured rebuttal rounds before principal synthesis, receiving full transcript history to challenge or reinforce claims.
+
+### Stage 3 — evidence-aware principal synthesis (default)
+A principal engineer agent receives all independent reviewer findings (along with optional static analysis and requirement evaluation results) and synthesizes the final PR review summary. The principal eliminates false positives, resolves overlaps, and makes final calls.
 
 ---
 
@@ -66,12 +66,16 @@ type AgentConfig = {
   name: string
   mandate: string         // plain English description of what this agent looks for
   model?: string          // optional model override per agent
+  system_prompt?: string  // extra reviewer instructions (appended to the built-in prompt)
+  min_confidence?: number // per-agent confidence threshold (defaults to debate.min_confidence)
+  include_patterns?: string[] // files this agent reviews (globs)
+  exclude_patterns?: string[] // files this agent ignores (globs)
 }
 
 type PrincipalSummary = {
   agreements: Finding[]
   disputes: { finding: Finding; rebuttal: Finding }[]
-  final_calls: { finding: Finding; decision: string }[]
+  final_calls: { finding: Finding; decision: string; status?: "accepted" | "rejected" | "deferred" }[]
   summary: string         // the markdown block posted to GitHub
 }
 ```
@@ -105,7 +109,7 @@ agents:
       unclear variable names, and changes that will be hard to maintain.
 
 debate:
-  rounds: 2               # how many debate rounds before synthesis
+  rounds: 0               # opt-in only: enabled: true or rounds: 1 for complex/high-risk PRs
   min_confidence: 0.6     # findings below this threshold are soft-filtered
 
 principal:
@@ -114,7 +118,7 @@ principal:
     Be direct. Show your reasoning. Surface genuine disagreements clearly.
 
 static_analysis:
-  enabled: true
+  enabled: false          # opt-in: runs shell commands from this file
   commands:
     - name: eslint
       run: npx eslint --format json -o eslint-report.json
@@ -136,8 +140,8 @@ context_enrichment:
 ## Tech stack
 
 - **Language:** TypeScript
-- **Runtime:** GitHub Actions (`runs-on: ubuntu-latest`)
-- **AI:** Anthropic API (user supplies `ANTHROPIC_API_KEY` as repo secret)
+- **Runtime:** GitHub Actions, node24 (`action.yml`) on `ubuntu-latest`
+- **AI:** 13 providers through a shared OpenAI-compatible base class (default Anthropic; user supplies the provider API key as a repo secret)
 - **GitHub API:** Octokit for reading diffs and posting comments
 - **Parallelism:** `Promise.all` for round 1, sequential per debate round
 - **Schema validation:** Zod for all agent outputs
@@ -153,13 +157,24 @@ swarm-review/
 │   └── workflows/
 │       └── example.yml       # example workflow for users to copy
 ├── src/
-│   ├── types.ts              # Finding, DebateTranscript, AgentConfig, PrincipalSummary
-│   ├── config.ts             # parse and validate .swarm.yml
+│   ├── types.ts              # Finding, DebateTranscript, AgentConfig, PrincipalSummary, all Zod schemas
+│   ├── config.ts             # parse and validate .swarm.yml (+ presets)
 │   ├── diff.ts               # fetch and parse the PR diff via Octokit
+│   ├── providers.ts          # LLM providers behind one retry/timeout interface
+│   ├── budget.ts             # strict per-run spend caps with fallback models
+│   ├── llm.ts                # structured-output calls with validation + retry
+│   ├── context.ts            # import tracing + signature extraction for prompts
+│   ├── static_analysis.ts    # linter/compiler execution with caps + containment
+│   ├── requirements.ts       # SpecBridge contract loading, coverage, SARIF
+│   ├── events.ts             # re-review commands, trust + fork detection
+│   ├── format.ts             # comment rendering, sanitization helpers
+│   ├── redact.ts             # secret masking for logs and posted comments
 │   ├── agents/
+│   │   ├── shared.ts         # per-agent provider resolution + finding rounds
 │   │   ├── review.ts         # round 1 — run all agents in parallel
-│   │   ├── debate.ts         # round 2 — run debate rounds
-│   │   └── principal.ts      # round 3 — synthesize and post comment
+│   │   ├── debate.ts         # round 2 — opt-in debate rounds
+│   │   ├── requirements.ts   # requirement-aware evaluation
+│   │   └── principal.ts      # round 3 — synthesize (with budget-exhaustion fallback)
 │   ├── prompts.ts            # all prompt templates in one place
 │   ├── github.ts             # post comment, update check run
 │   └── index.ts              # entrypoint, orchestrates the three rounds
@@ -178,13 +193,18 @@ Build in this order. Do not skip ahead.
 1. `src/types.ts` — define all types and Zod schemas. Nothing else until this is solid.
 2. `src/config.ts` — parse `.swarm.yml`, validate against schema, export `SwarmConfig`
 3. `src/diff.ts` — fetch PR diff from GitHub API, return as structured `FileDiff[]`
-4. `src/prompts.ts` — write all prompt templates. Keep prompts centralized, never inline.
-5. `src/agents/review.ts` — round 1. Run all agents in parallel, collect `Finding[]`
-6. `src/agents/debate.ts` — round 2. Run debate rounds, build `DebateTranscript`
-7. `src/agents/principal.ts` — round 3. Synthesize, format, post GitHub comment
-8. `src/index.ts` — wire everything together
-9. `action.yml` — package as GitHub Action
-10. `README.md` — write last, when the thing actually works
+4. `src/providers.ts` + `src/budget.ts` — provider interface with retries, spend caps
+5. `src/prompts.ts` — write all prompt templates. Keep prompts centralized, never inline.
+6. `src/llm.ts` + `src/agents/shared.ts` — structured calls, per-agent rounds
+7. `src/agents/review.ts` — round 1. Run all agents in parallel, collect `Finding[]`
+8. `src/static_analysis.ts` + `src/context.ts` — local signals and codebase context
+9. `src/agents/debate.ts` — round 2 (opt-in). Run debate rounds, build `DebateTranscript`
+10. `src/requirements.ts` + `src/agents/requirements.ts` — SpecBridge evaluation
+11. `src/agents/principal.ts` + `src/format.ts` + `src/redact.ts` — synthesize, sanitize, render
+12. `src/events.ts` + `src/github.ts` — commands, trust checks, posting
+13. `src/index.ts` — wire everything together
+14. `action.yml` — package as GitHub Action
+15. `README.md` — write last, when the thing actually works
 
 ---
 
@@ -239,7 +259,7 @@ That output. That is the goal. Every implementation decision should serve produc
 
 ## Roadmap
 
-The strategic development goals and future milestones are documented in [ROADMAP.md](file:///c:/Users/evang/Documents/Coding/Swarm-Review/ROADMAP.md).
+The strategic development goals and future milestones are documented in [ROADMAP.md](ROADMAP.md).
 
 > [!IMPORTANT]
 > **Rule for Future AI Agents:**

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ principal: blocking until this path uses parameterized queries.
 
 Swarm-Review's multi-agent debate architecture has been empirically benchmarked against [SpecBench v0.2](https://github.com/EvanGribar/SpecBench) across 5 distinct review configurations (Single-Agent, Swarm without Debate, Swarm with Debate, Swarm Debate + Static Analysis, and Requirement-Aware SpecBridge).
 
-On a controlled 10-case requirement-violation benchmark, independent reviewers plus principal synthesis matched the debate configuration while reducing cost and latency. The benchmark is directional evidence, not a claim of general code-review quality; see the full methodology and raw results:
+On a controlled 10-case requirement-violation benchmark, independent reviewers plus principal synthesis matched the debate configuration while reducing cost and latency. The benchmark is directional evidence, not a claim of general code-review quality (n=10 SpecBench v0.2 cases on `gpt-4o-mini`, benchmark authored by the same team); see the full methodology and raw results:
 - **Principal Synthesis Sufficiency**: Independent reviewers plus principal synthesis (`swarm-no-debate`) achieves **100.0% Recall** and **100.0% Precision** on SpecBench v0.2 requirement violation cases. Principal synthesis alone filters false positives without requiring multi-agent debate rounds.
 - **Debate Cost & Latency Penalty**: Structured debate (`swarm-with-debate`) achieves identical 100% precision and recall as non-debate swarm, while adding **+26.2% cost** ($0.0077 vs $0.0061) and **+38.1% runtime latency** (116.4s vs 84.3s).
 - **SpecBridge Requirement Efficiency**: Contract-aware SpecBridge evaluation delivers **98.4% F1** at **22% of the cost** ($0.0017 vs $0.0077) and **27% of the latency** (31.9s vs 116.4s).
@@ -100,6 +100,9 @@ jobs:
 
       - name: Run swarm-review
         uses: EvanGribar/Swarm-Review@v1
+        env:
+          # Map each provider key your .swarm.yml references ($NAME) from a secret.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -230,11 +233,17 @@ principal: blocking until this path uses parameterized queries.
   - `agents[].include_patterns`: glob patterns of files this agent should review.
   - `agents[].exclude_patterns`: glob patterns of files this agent should ignore.
 - `budget.max_cost_usd`: optional strict per-run spend cap. Before every call, swarm-review reserves a conservative worst-case cost and never starts a call that would exceed the cap. Successful calls settle to an observed-output upper bound; failed or ambiguous calls retain their reservation because they may still be billable.
-- `budget.fallback_model`: optional cheaper model from the same provider to use when the primary model no longer fits. Models without known pricing need either a known fallback or a `budget.model_prices` entry when budgeting is enabled.
+- `budget.fallback_model`: optional cheaper model from the same provider family to use when the primary model no longer fits. The fallback is sent to the primary provider's endpoint, so a cross-family model will fail. Models without known pricing need either a known fallback or a `budget.model_prices` entry when budgeting is enabled.
 - `budget.max_output_tokens`: maximum output tokens reserved and requested per call. Defaults to `4096`.
 - `budget.model_prices`: optional per-model prices (USD per 1M input/output tokens) for models without known pricing, e.g. self-hosted gateways or brand-new model IDs. Example: `model_prices: { my-model: { input: 1.0, output: 3.0 } }`.
+- `debate.enabled`: set `true` (or `rounds: 1`) to opt into structured debate for complex or high-risk PRs. Defaults to non-debate synthesis.
 - `debate.rounds`: how many debate rounds to run after the first-pass review.
 - `debate.min_confidence`: findings below this threshold are filtered out.
+- `requirements.enabled`: validate the PR against `.specbridge/requirements.json` (see [SpecBridge integration](docs/SPECBRIDGE.md)).
+- `requirements.contract_path`: path to the requirement contract. Defaults to `.specbridge/requirements.json`.
+- `requirements.fail_on_violation`: request changes when blocking requirements are violated. Defaults to `false`.
+- `requirements.upload_sarif`: reserved for SARIF upload flows. Defaults to `false`.
+- `requirements.max_file_size_kb`: reject contracts larger than this. Defaults to `256`.
 - `principal.mandate`: instructions for the synthesis agent.
 - `output.mode`: controls whether the transcript is included in the PR comment.
 - `output.inline`: whether to publish accepted findings as inline GitHub review comments.
@@ -419,7 +428,7 @@ provider:
     model: gemini-2.0-flash-exp
 ```
 
-**Note:** Gemini uses the Google AI API with the API key passed as a query parameter. Visit [Google AI Studio](https://makersuite.google.com/app/apikey) to get an API key and check their [documentation](https://ai.google.dev/gemini-api/docs) for available models.
+**Note:** Gemini is called via Google's OpenAI-compatible endpoint with `Authorization: Bearer $GEMINI_API_KEY`. Visit [Google AI Studio](https://makersuite.google.com/app/apikey) to get an API key and check their [documentation](https://ai.google.dev/gemini-api/docs) for available models.
 
 ### Custom Provider
 
@@ -485,6 +494,11 @@ provider:
 - `total-output-tokens`: total output tokens consumed by LLM calls.
 - `total-cost`: estimated total cost of LLM calls in USD.
 - `total-calls`: total number of LLM calls executed.
+- `coverage-path`: path to the generated SpecBridge coverage report (only when `requirements.enabled`).
+- `sarif-path`: path to the generated SpecBridge SARIF report (only when `requirements.enabled`).
+- `requirement-count`: number of requirement criteria evaluated (only when `requirements.enabled`).
+- `violated-count`: number of evidenced violated criteria (only when `requirements.enabled`).
+- `not-verifiable-count`: number of criteria that could not be verified (only when `requirements.enabled`).
 
 ## Example Result
 
@@ -523,8 +537,8 @@ npm test
 - Large diffs increase token usage and can reduce claim quality due to context compression.
 - High agent counts and many debate rounds increase runtime and cost linearly.
 - Recommended starting point:
-  - 3-5 agents
-  - 1-2 debate rounds
+  - 3 agents (`security`, `performance`, `architecture`)
+  - 0 debate rounds (opt into 1 round only for complex or high-risk PRs)
   - confidence threshold of 0.6-0.75
 
 Tune these values based on repository size and expected review depth.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,30 +1,30 @@
 # Swarm-Review Roadmap
 
-This roadmap contains only work planned after the v1.0.0 production release.
+This roadmap contains only upcoming, non-completed milestones.
 
 ```mermaid
 gantt
     title Swarm-Review Future Releases
     dateFormat YYYY-MM-DD
     section Future Milestones
-    v1.2.0 (Local Tools and Dashboard) : 2026-08-30, 20d
-    v1.3.0 (IDE and Policy Integrations) : 2026-09-20, 20d
+    v1.4.0 (Hardening and Supply Chain) : 2026-09-04, 14d
+    v1.5.0 (Local Tools and Dashboard) : 2026-09-18, 20d
 ```
 
 ## Vision
 
 Swarm-review should remain zero-hosting by default, read like a real engineering review, and make model cost and behavior observable and controllable.
 
-## v1.2.0: Local Tools and Dashboard
+## v1.4.0: Hardening and Supply Chain
+
+- Land the trust-boundary work: fork-gated static analysis, secret redaction on all posted output, contained report files.
+- Finish the dependency modernization (zod v4, js-yaml v5, octokit 22) and clear the code-scanning backlog.
+- Publish npm-hosted SpecBridge packages to replace release-tarball dependencies.
+
+## v1.5.0: Local Tools and Dashboard
 
 - Add a local CLI for reviewing working-tree changes and branch diffs.
 - Provide an optional dashboard for exploring findings, rebuttals, and principal decisions.
 - Support reusable, versioned agent-roster packages.
-
-## v1.3.0: IDE and Policy Integrations
-
-- Add editor integrations for pre-push review loops.
-- Integrate language-server and code-graph context providers.
-- Support branch-specific policy rules and agent assignments.
 
 This roadmap is a living document. Please use GitHub issues to propose or discuss future milestones.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: swarm-review
-description: Run a swarm of AI reviewers on pull requests with multi-provider support (Anthropic, OpenAI, OpenRouter, custom).
+description: Run a swarm of AI reviewers on pull requests with multi-provider support (Anthropic, OpenAI, OpenRouter, OpenClaw, Hermes, Groq, Together, Mistral, Cohere, Perplexity, Hyperbolic, Gemini, custom).
 author: EvanGribar
 branding:
   icon: users

--- a/docs/EVALUATION_RESULTS.md
+++ b/docs/EVALUATION_RESULTS.md
@@ -1,6 +1,6 @@
 # Swarm-Review Evaluation Results & Architecture Benchmarks
 
-This report presents a controlled, empirical evaluation of Swarm-Review's multi-agent debate architecture against four baseline review configurations across the 10-case **SpecBench v0.2** benchmark suite.
+This report presents a controlled, empirical evaluation of Swarm-Review's multi-agent debate architecture across five review configurations (a single-agent baseline plus four multi-agent and requirement-aware variants) on the 10-case **SpecBench v0.2** benchmark suite.
 
 ---
 

--- a/docs/SPECBRIDGE.md
+++ b/docs/SPECBRIDGE.md
@@ -1,6 +1,6 @@
 # SpecBridge requirement-aware review
 
-Swarm-Review v1.1 can evaluate a checked-in [SpecBridge](https://github.com/EvanGribar/SpecBridge) `1.0` contract. It is opt-in; without `requirements.enabled: true`, existing review behavior is unchanged.
+Swarm-Review (requirement-aware review introduced in v1.1) can evaluate a checked-in [SpecBridge](https://github.com/EvanGribar/SpecBridge) `1.0` contract. It is opt-in; without `requirements.enabled: true`, existing review behavior is unchanged.
 
 ```yaml
 requirements:
@@ -15,7 +15,7 @@ Only a repository-relative local JSON path is supported. The loader rejects abso
 Every criterion becomes exactly one `satisfied`, `violated`, `not_verifiable`, or `not_applicable` record. Violations require source-code evidence; budget exhaustion becomes `not_verifiable`. `swarm-review-output/coverage.json` is the source of truth and `swarm-review-output/findings.sarif` is generated from it with `@specbridge/sarif`; only evidenced violations appear in SARIF.
 
 ```yaml
-- uses: github/codeql-action/upload-sarif@v3
+- uses: github/codeql-action/upload-sarif@v4
   with:
     sarif_file: swarm-review-output/findings.sarif
 ```


### PR DESCRIPTION
## What does this PR change?

Docs-consistency batch from the multi-agent audit (all verified against code):

- AGENTS.md: fixed dead absolute ROADMAP link, debate example rounds 2->0, static_analysis example true->false, tech stack (node24, 13 providers), full file tree + build order, data-model fields, stage numbering (debate=2, synthesis=3).
- ROADMAP.md: removed shipped v1.2.0/v1.3.0 per the AGENTS.md rule; future-only v1.4.0/v1.5.0.
- README.md: Practical Limits now 3 agents / 0 rounds; 5 missing SpecBridge outputs documented; debate.enabled + requirements.* fields documented; fallback same-family note; quickstart maps provider $VAR via env; evaluation caveat (n=10, gpt-4o-mini, same-team benchmark); Gemini Bearer note.
- action.yml: description lists all 13 providers.
- docs/SPECBRIDGE.md: upload-sarif v3->v4, version stamp fixed.
- docs/EVALUATION_RESULTS.md: four baselines -> five configurations.

No src/, workflow, or config changes; no dist rebuild needed.

## Verification

- [x] npm run typecheck passes
- [ ] CI green
